### PR TITLE
Update test-connection.yaml

### DIFF
--- a/charts/memgraph/templates/tests/test-connection.yaml
+++ b/charts/memgraph/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-memgraph-test"
+  name: "{{ include "memgraph.fullname" . }}-test"
   labels:
     {{- include "memgraph.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
"{{ .Release.Name }}-memgraph-test" does not generate a unique name, which is required when a helm chart includes multiple instances of the memgraph chart.

For example when a chart has two dependencies on memgraph:

```helm
dependencies:
- name: memgraph
  version: ~0.1.0
  repository: https://memgraph.github.io/helm-charts
- name: memgraph
  alias: memgraph2
  version: ~0.1.0
  repository: https://memgraph.github.io/helm-charts
```