### PR TITLE
Fix: Add correct url for liveness/readiness of Lab

### DIFF
--- a/charts/memgraph-lab/templates/deployment.yaml
+++ b/charts/memgraph-lab/templates/deployment.yaml
@@ -39,11 +39,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /check
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /check
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
The URL `/` is really slow to be used for the liveness/readiness of the Lab because it loads the front end and returns the full code along with the HTML application code.

Url `/check` is the one that should be used instead because it is simple, fast, and does no processing at all.