### PR TITLE
Fix running as a root

### DIFF
--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -27,7 +27,28 @@ spec:
         {{- toYaml . | nindent 4 }}
       {{- end }}
     spec:
-      securityContext:
+      initContainers:
+      - name: init-volume-mounts
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        volumeMounts:
+        {{- if $.Values.persistentVolumeClaim.storagePVC }}
+        - name: {{ include "memgraph.fullname" . }}-lib-storage
+          mountPath: /var/lib/memgraph
+        {{- end }}
+        {{- if $.Values.persistentVolumeClaim.logPVC }}
+        - name: {{ include "memgraph.fullname" . }}-log-storage
+          mountPath: /var/log/memgraph
+        {{- end }}
+        command: [ "/bin/sh","-c" ]
+        args: [ "chown -R memgraph:memgraph /var/log; chown -R memgraph:memgraph /var/lib" ]
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ "all" ]
+            add: [ "CHOWN" ]
+          runAsUser: 0
+          runAsNonRoot: false
       containers:
         - name: memgraph
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -36,8 +57,6 @@ spec:
           - {{ . | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            runAsUser: 0
           ports:
             - name: memgraph
               containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
Introduce init containers that should fix an issue with volume ownership.  This enables Memgraph not being run as a root in k8s. 