### PR TITLE
update memgraph statefulset to accept tolerations and nodeSelectors

### DIFF
--- a/charts/memgraph/README.md
+++ b/charts/memgraph/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the Memgraph chart and 
 | `statefulSetAnnotations`                    | Annotations to add to the stateful set                                                              | `{}`                                    |
 | `podAnnotations`                            | Annotations to add to the pod                                                                       | `{}`                                    |
 | `resources`                                 | CPU/Memory resource requests/limits. Left empty by default.                                         | `{}`                                    |
+| `tolerations`                               | Tolerations for pod. Left empty by default.                                                         | `[]`                                    |
 | `serviceAccount.create`                     | Specifies whether a service account should be created                                               | `true`                                  |
 | `serviceAccount.annotations`                | Annotations to add to the service account                                                           | `{}`                                    |
 | `serviceAccount.name`                       | The name of the service account to use. If not set and create is true, a name is generated.         | `""`                                    |
@@ -72,6 +73,7 @@ The following table lists the configurable parameters of the Memgraph chart and 
 | `probes.startup.initialDelaySeconds`        | Initial delay for startup probe                                                                     | `10`                                    |
 | `probes.startup.periodSeconds`              | Period seconds for startup probe                                                                    | `10`                                    |
 | `probes.startup.failureThreshold`           | Failure threshold for startup probe                                                                 | `30`                                    |
+| `nodeSelectors`                             | Node selectors for pod. Left empty by default.                                                      | `{}`                                    |
 
 **Note:** It's often recommended not to specify default resources and leave it as a conscious choice for the user. If you want to specify resources, uncomment the following lines in your `values.yaml`, adjust them as necessary:
 

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -147,6 +147,14 @@ spec:
             - name: {{ include "memgraph.fullname" . }}-lib-storage
               mountPath: /var/log/memgraph
           {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.affinity.nodeKey .Values.affinity.nodeValue }}
       affinity:
         nodeAffinity:

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -20,6 +20,10 @@ affinity:
   nodeKey:
   nodeValue:
 
+nodeSelector: {}
+
+tolerations: []
+
 service:
   ## ClusterIP, NodePort, LoadBalancer
   # ClusterIP keep the service inside the cluster makes it secure


### PR DESCRIPTION
This allows the statefulset to use tolerations and nodeSelectors for workloads. The defaults are backwards-compatible.