### PR TITLE
Improve cluster-setup test

### DIFF
--- a/charts/memgraph-high-availability/templates/tests/test-cluster-setup.yaml
+++ b/charts/memgraph-high-availability/templates/tests/test-cluster-setup.yaml
@@ -18,36 +18,59 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          instances=$(echo 'SHOW INSTANCES;' | mgconsole --host memgraph-coordinator-1.default.svc.cluster.local --port 7687)
-          echo "$instances"
-          num_leaders=$(echo "$instances" | grep -c "leader")
-          if [ $num_leaders -ne 1 ]; then
+          is_valid_view_of_cluster() {
+            local instances=$1 # Function accepts one argument = the result of `SHOW INSTANCES`
+            num_leaders=$(echo "$instances" | grep -c "leader")
+            if [ $num_leaders -ne 1 ]; then
               echo "Expected 1 leader after registration, got $num_leaders."
-              exit 1
-          fi
+              return 1
+            fi
 
-          num_followers=$(echo "$instances" | grep -c "follower")
-          if [ $num_followers -ne 2 ]; then
+            num_followers=$(echo "$instances" | grep -c "follower")
+            if [ $num_followers -ne 2 ]; then
               echo "Expected 2 followers after registration, got $num_followers."
-              exit 1
-          fi
+              return 1
+            fi
 
-          num_mains=$(echo "$instances" | grep -c "main")
-          if [ $num_mains -ne 1 ]; then
+            num_mains=$(echo "$instances" | grep -c "main")
+            if [ $num_mains -ne 1 ]; then
               echo "Expected 1 main after registration, got $num_mains."
-              exit 1
-          fi
+              return 1
+            fi
 
-          num_replicas=$(echo "$instances" | grep -c "replica")
-          if [ $num_replicas -ne 1 ]; then
+            num_replicas=$(echo "$instances" | grep -c "replica")
+            if [ $num_replicas -ne 1 ]; then
               echo "Expected 1 replica after registration, got $num_replicas."
-              exit 1
+              return 1
+            fi
+
+            num_instances_down=$(echo "instances" | grep -c "down")
+            if [ $num_instances_down -ne 0 ]; then
+              echo "Expected 0 instances down after registration, got $num_instances_down."
+              return 1
+            fi
+
+            return 0
+          }
+          # Check if coordinator 1 sees the cluster correctly
+          coord1_instances=$(echo 'SHOW INSTANCES;' | mgconsole --host memgraph-coordinator-1.default.svc.cluster.local --port 7687)
+          is_valid_view_of_cluster "$coord1_instances"
+          if [ $? -ne 0 ]; then
+            exit 1
           fi
 
-          num_instances_down=$(echo "instances" | grep -c "down")
-          if [ $num_instances_down -ne 0 ]; then
-              echo "Expected 0 instances down after registration, got $num_instances_down."
-              exit 1
+          # Check if coordinator 2 sees the cluster correctly
+          coord2_instances=$(echo 'SHOW INSTANCES;' | mgconsole --host memgraph-coordinator-2.default.svc.cluster.local --port 7687)
+          is_valid_view_of_cluster "$coord2_instances"
+          if [ $? -ne 0 ]; then
+            exit 1
+          fi
+
+          # Check if coordinator 3 sees the cluster correctly
+          coord3_instances=$(echo 'SHOW INSTANCES;' | mgconsole --host memgraph-coordinator-3.default.svc.cluster.local --port 7687)
+          is_valid_view_of_cluster "$coord3_instances"
+          if [ $? -ne 0 ]; then
+            exit 1
           fi
 
           exit 0


### PR DESCRIPTION
Restart tests cannot be added to Helm, they're not suited for this at the moment. Improved cluster-setup tests by checking view from each coordinator.
Tests should start working with 2.18.1