### PR TITLE
Update contribution guide, bug repot and pre-commit.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,7 @@ title: ""
 labels: bug
 ---
 
-**Chart type:**
+**Chart type**
 Specify the chart type you experienced issues with (Memgraph Standalone, Memgraph HA,  Memgraph LAB)
 
 **Chart version:**

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,27 +1,21 @@
-name: Bug Report
-description: File a bug report
-title: "[Bug]: "
-labels: ["bug"]
-assignees:
-- katarinasupe
-- antejavor
-body:
-- type: markdown
-  attributes:
-    value: |
-      ## Bug Report
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug
+---
 
-      **Chart type:**
-      _Specify the chart type you experienced issues with (Memgraph Standalone, Memgraph HA,  Memgraph LAB)_
+**Chart type:**
+Specify the chart type you experienced issues with (Memgraph Standalone, Memgraph HA,  Memgraph LAB)
 
-      **Chart version:**
-      _Specify the version of the chart you are running._
+**Chart version:**
+Specify the version of the chart you are running.
 
-      **What happened?**
-      _Describe the issue and what you expected to happen._
+**What happened?**
+Describe the issue and what you expected to happen.
 
-      **Environment:**
-      _Specify the environment where the issue occurred and how it could be related to the bug._
+**Environment:**
+Specify the environment where the issue occurred and how it could be related to the bug.
 
-      **Relevant log output:**
-      _Please copy and paste any relevant log output from pods and containers._
+**Relevant log output:**
+Please copy and paste any relevant log output from pods and containers.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,6 @@ repos:
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
-  - id: check-yaml
-    exclude: ^charts/(memgraph|memgraph-lab|memgraph-high-availability)/templates/
   - id: check-json
   - id: mixed-line-ending
   - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-json
+  - id: check-yaml
+    exclude: ^charts/(memgraph|memgraph-lab|memgraph-high-availability)/templates/
   - id: mixed-line-ending
   - id: check-merge-conflict
   - id: detect-private-key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ There are two main types of contributions:
 1. **Bug fixes**
 2. **New features**
 
-Both types of fixes should be applied to the `release` branch, that is currently active based on the upcoming [milestone](https://github.com/memgraph/helm-charts/milestone/2) for example `release-0.1.3` branch.
+Both types of fixes should be applied to the `main` branch.
 
 In order for a pull request to be merged, a review by two code owners is required and the tests need to pass remotely.
 


### PR DESCRIPTION
As part of the repo maintenance, making the contribution process easier, updating bug reports from that broken, and relaxing pre-commit hooks. 