### PR TITLE
Fix max map count

### DIFF
--- a/charts/memgraph-high-availability/README.md
+++ b/charts/memgraph-high-availability/README.md
@@ -26,41 +26,43 @@ helm install <release-name> memgraph/memgraph-high-availability -f values.yaml
 
 The following table lists the configurable parameters of the Memgraph chart and their default values.
 
-| Parameter                                   | Description                                                                                         | Default                                 |
-|---------------------------------------------|-----------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `memgraph.image.repository`                 | Memgraph Docker image repository                                                                    | `memgraph/memgraph`                     |
-| `memgraph.image.tag`                        | Specific tag for the Memgraph Docker image. Overrides the image tag whose default is chart version. | `2.17.0`                                |
-| `memgraph.image.pullPolicy`                 | Image pull policy                                                                                   | `IfNotPresent`                          |
-| `memgraph.env.MEMGRAPH_ENTERPRISE_LICENSE`  | Memgraph enterprise license                                                                         | `<your-license>`                        |
-| `memgraph.env.MEMGRAPH_ORGANIZATION_NAME`   | Organization name                                                                                   | `<your-organization-name>`              |
-| `memgraph.probes.startup.failureThreshold`  | Startup probe failure threshold                                                                     | `30`                                    |
-| `memgraph.probes.startup.periodSeconds`     | Startup probe period in seconds                                                                     | `10`                                    |
-| `memgraph.probes.readiness.initialDelaySeconds` | Readiness probe initial delay in seconds                                                         | `5`                                     |
-| `memgraph.probes.readiness.periodSeconds`   | Readiness probe period in seconds                                                                   | `5`                                     |
-| `memgraph.probes.liveness.initialDelaySeconds` | Liveness probe initial delay in seconds                                                           | `30`                                    |
-| `memgraph.probes.liveness.periodSeconds`    | Liveness probe period in seconds                                                                    | `10`                                    |
-| `memgraph.data.volumeClaim.storagePVC`      | Enable storage PVC                                                                                  | `true`                                 |
-| `memgraph.data.volumeClaim.storagePVCSize`  | Size of the storage PVC                                                                             | `1Gi`                                   |
-| `memgraph.data.volumeClaim.logPVC`          | Enable log PVC                                                                                      | `false`                                 |
-| `memgraph.data.volumeClaim.logPVCSize`      | Size of the log PVC                                                                                 | `256Mi`                                 |
-| `memgraph.coordinators.volumeClaim.storagePVC` | Enable storage PVC for coordinators                                                               | `true`                                 |
-| `memgraph.coordinators.volumeClaim.storagePVCSize` | Size of the storage PVC for coordinators                                                         | `1Gi`                                   |
-| `memgraph.coordinators.volumeClaim.logPVC`  | Enable log PVC for coordinators                                                                     | `false`                                 |
-| `memgraph.coordinators.volumeClaim.logPVCSize` | Size of the log PVC for coordinators                                                              | `256Mi`                                 |
-| `memgraph.affinity.enabled`                 | Enables affinity so each instance is deployed to unique node                                        | `true`                                 |
-| `data`                                      | Configuration for data instances                                                                    | See `data` section                      |
-| `coordinators`                              | Configuration for coordinator instances                                                             | See `coordinators` section              |
+| Parameter                                          | Description                                                                                         | Default                    |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------- |
+| `memgraph.image.repository`                        | Memgraph Docker image repository                                                                    | `memgraph/memgraph`        |
+| `memgraph.image.tag`                               | Specific tag for the Memgraph Docker image. Overrides the image tag whose default is chart version. | `2.17.0`                   |
+| `memgraph.image.pullPolicy`                        | Image pull policy                                                                                   | `IfNotPresent`             |
+| `memgraph.env.MEMGRAPH_ENTERPRISE_LICENSE`         | Memgraph enterprise license                                                                         | `<your-license>`           |
+| `memgraph.env.MEMGRAPH_ORGANIZATION_NAME`          | Organization name                                                                                   | `<your-organization-name>` |
+| `memgraph.probes.startup.failureThreshold`         | Startup probe failure threshold                                                                     | `30`                       |
+| `memgraph.probes.startup.periodSeconds`            | Startup probe period in seconds                                                                     | `10`                       |
+| `memgraph.probes.readiness.initialDelaySeconds`    | Readiness probe initial delay in seconds                                                            | `5`                        |
+| `memgraph.probes.readiness.periodSeconds`          | Readiness probe period in seconds                                                                   | `5`                        |
+| `memgraph.probes.liveness.initialDelaySeconds`     | Liveness probe initial delay in seconds                                                             | `30`                       |
+| `memgraph.probes.liveness.periodSeconds`           | Liveness probe period in seconds                                                                    | `10`                       |
+| `memgraph.data.volumeClaim.storagePVC`             | Enable storage PVC                                                                                  | `true`                     |
+| `memgraph.data.volumeClaim.storagePVCSize`         | Size of the storage PVC                                                                             | `1Gi`                      |
+| `memgraph.data.volumeClaim.logPVC`                 | Enable log PVC                                                                                      | `false`                    |
+| `memgraph.data.volumeClaim.logPVCSize`             | Size of the log PVC                                                                                 | `256Mi`                    |
+| `memgraph.coordinators.volumeClaim.storagePVC`     | Enable storage PVC for coordinators                                                                 | `true`                     |
+| `memgraph.coordinators.volumeClaim.storagePVCSize` | Size of the storage PVC for coordinators                                                            | `1Gi`                      |
+| `memgraph.coordinators.volumeClaim.logPVC`         | Enable log PVC for coordinators                                                                     | `false`                    |
+| `memgraph.coordinators.volumeClaim.logPVCSize`     | Size of the log PVC for coordinators                                                                | `256Mi`                    |
+| `memgraph.affinity.enabled`                        | Enables affinity so each instance is deployed to unique node                                        | `true`                     |
+| `data`                                             | Configuration for data instances                                                                    | See `data` section         |
+| `coordinators`                                     | Configuration for coordinator instances                                                             | See `coordinators` section |
+| `sysctlInitContainer.enabled`                      | Enable the init container to set sysctl parameters                                                  | `true`                     |
+| `sysctlInitContainer.maxMapCount`                  | Value for `vm.max_map_count` to be set by the init container                                        | `262144`                   |
 
 For the `data` and `coordinators` sections, each item in the list has the following parameters:
 
-| Parameter                                   | Description                                                                                         | Default                                 |
-|---------------------------------------------|-----------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `id`                                        | ID of the instance                                                                                  | `0` for data, `1` for coordinators      |
-| `boltPort`                                  | Bolt port of the instance                                                                           | `7687`                                  |
-| `managementPort`                            | Management port of the data instance                                                                | `10000`                                 |
-| `replicationPort` (data only)               | Replication port of the data instance                                                               | `20000`                                 |
-| `coordinatorPort` (coordinators only)       | Coordinator port of the coordinator instance                                                        | `12000`                                 |
-| `args`                                      | List of arguments for the instance                                                                  | See `args` section                      |
+| Parameter                             | Description                                  | Default                            |
+| ------------------------------------- | -------------------------------------------- | ---------------------------------- |
+| `id`                                  | ID of the instance                           | `0` for data, `1` for coordinators |
+| `boltPort`                            | Bolt port of the instance                    | `7687`                             |
+| `managementPort`                      | Management port of the data instance         | `10000`                            |
+| `replicationPort` (data only)         | Replication port of the data instance        | `20000`                            |
+| `coordinatorPort` (coordinators only) | Coordinator port of the coordinator instance | `12000`                            |
+| `args`                                | List of arguments for the instance           | See `args` section                 |
 
 The `args` section contains a list of arguments for the instance. The default values are the same for all instances:
 

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -52,6 +52,15 @@ spec:
             add: [ "CHOWN" ]
           runAsUser: 0
           runAsNonRoot: false
+    {{- if $.Values.sysctlInitContainer.enabled }}
+      - name: init-sysctl
+        image: busybox
+        command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        {{- end }}
+
       containers:
       - name: memgraph-coordinator
         image: "{{ $.Values.memgraph.image.repository }}:{{ $.Values.memgraph.image.tag }}"

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -52,6 +52,15 @@ spec:
             add: [ "CHOWN" ]
           runAsUser: 0
           runAsNonRoot: false
+    {{- if $.Values.sysctlInitContainer.enabled }}
+      - name: init-sysctl
+        image: busybox
+        command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        {{- end }}
+
       containers:
       - name: memgraph-data
         image: "{{ $.Values.memgraph.image.repository }}:{{ $.Values.memgraph.image.tag }}"

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -39,6 +39,13 @@ memgraph:
   affinity:
     enabled: true
 
+# If you are experiencing issues with the sysctlInitContainer, you can disable it here.
+# This is made to increase the max_map_count, necessary for high memory loads in Memgraph
+# If you are experiencing crashing pod with the: Max virtual memory areas vm.max_map_count is too low
+# you can increase the maxMapCount value.
+sysctlInitContainer:
+  enabled: true
+  maxMapCount: 262144
 
 data:
 - id: "0"

--- a/charts/memgraph/README.md
+++ b/charts/memgraph/README.md
@@ -78,7 +78,8 @@ The following table lists the configurable parameters of the Memgraph chart and 
 | `probes.startup.failureThreshold`           | Failure threshold for startup probe                                                                                              | `30`                                   |
 | `nodeSelectors`                             | Node selectors for pod. Left empty by default.                                                                                   | `{}`                                   |
 | `customQueryModules`                        | List of custom Query modules that should be mounted to Memgraph Pod                                                              | `[]`                                   |
-
+| `sysctlInitContainer.enabled`               | Enable the init container to set sysctl parameters                                                                               | `true`                                 |
+| `sysctlInitContainer.maxMapCount`           | Value for `vm.max_map_count` to be set by the init container                                                                     | `262144`                               |
 **Note:** It's often recommended not to specify default resources and leave it as a conscious choice for the user. If you want to specify resources, uncomment the following lines in your `values.yaml`, adjust them as necessary:
 
 ```yaml

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
           command: ['sh', '-c', 'sysctl -w vm.max_map_count=65530']
           securityContext:
             privileged: true
-          runAsUser: 0
+            runAsUser: 0
           {{- end }}
       terminationGracePeriodSeconds: {{ .Values.container.terminationGracePeriodSeconds }}
       securityContext:

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -69,7 +69,14 @@ spec:
               add: ["CHOWN"]
             runAsUser: 0
             runAsNonRoot: false
-
+        {{- if .Values.sysctlInitContainer.enabled }}
+        - name: init-sysctl
+          image: busybox
+          command: ['sh', '-c', 'sysctl -w vm.max_map_count=65530']
+          securityContext:
+            privileged: true
+          runAsUser: 0
+          {{- end }}
       terminationGracePeriodSeconds: {{ .Values.container.terminationGracePeriodSeconds }}
       securityContext:
       {{- if .Values.useImagePullSecrets }}

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -72,7 +72,7 @@ spec:
         {{- if .Values.sysctlInitContainer.enabled }}
         - name: init-sysctl
           image: busybox
-          command: ['sh', '-c', 'sysctl -w vm.max_map_count=65530']
+          command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ .Values.sysctlInitContainer.maxMapCount }}']
           securityContext:
             privileged: true
             runAsUser: 0

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -147,5 +147,10 @@ customQueryModules: []
 #   file: ""
 
 
+# If you are experiencing issues with the sysctlInitContainer, you can disable it here.
+# This is made to increase the max_map_count, necessary for high memory loads in Memgraph
+# If you are experiencing crashing pod with the: Max virtual memory areas vm.max_map_count is too low
+# you can increase the maxMapCount value.
 sysctlInitContainer:
   enabled: true
+  maxMapCount: 262144

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -20,6 +20,7 @@ affinity:
   nodeKey:
   nodeValue:
 
+
 nodeSelector: {}
 
 tolerations: []
@@ -120,7 +121,6 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-
 container:
   terminationGracePeriodSeconds: 1800
   probes:
@@ -145,3 +145,7 @@ customQueryModules: []
 # - volume: ""
 #   Must be present in the ConfigMap referenced with `volume`
 #   file: ""
+
+
+sysctlInitContainer:
+  enabled: true


### PR DESCRIPTION
This fix inclued setting up `vm.max_map_count` to `262144` by default, as specified [here](https://github.com/memgraph/helm-charts/pull/79/files#diff-be8b88ae1eaeb2c07e976c2f8d2852ea7cf4b84478872c2273c63ba0ee4464fcR156) 

There is an optionality included there. 
