### PR TITLE
Update security context for HA chart

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -82,23 +82,21 @@ spec:
         - name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
           mountPath: /var/log/memgraph
         command: [ "/bin/sh","-c" ]
-        args: [ "chown -R memgraph:memgraph /var/log; chown -R memgraph:memgraph /var/lib" ]
+        args: [ "chown -R memgraph:memgraph /var/log/memgraph; chown -R memgraph:memgraph /var/lib/memgraph" ]
         securityContext:
-          privileged: true
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
+          runAsUser: 0 # Run as root
           capabilities:
-            drop: [ "all" ]
+            drop: [ "ALL" ]
             add: [ "CHOWN" ]
-          runAsUser: 0
-          runAsNonRoot: false
-    {{- if $.Values.sysctlInitContainer.enabled }}
+      {{- if $.Values.sysctlInitContainer.enabled }}
       - name: init-sysctl
         image: busybox
         command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
         securityContext:
           privileged: true
           runAsUser: 0
-        {{- end }}
+      {{- end }}
 
       containers:
       - name: memgraph-coordinator
@@ -140,9 +138,7 @@ spec:
       spec:
         accessModes:
         - {{ $.Values.storage.libStorageAccessMode}}
-        {{- if $.Values.storage.libStorageClassName }}
         storageClassName: {{ $.Values.storage.libStorageClassName }}
-        {{- end }}
         resources:
           requests:
             storage: {{ $.Values.storage.libPVCSize }}
@@ -152,9 +148,7 @@ spec:
       spec:
         accessModes:
         - {{ $.Values.storage.logStorageAccessMode}}
-        {{- if $.Values.storage.logStorageClassName }}
         storageClassName: {{ $.Values.storage.logStorageClassName }}
-        {{- end }}
         resources:
           requests:
             storage: {{ $.Values.storage.logPVCSize }}

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -132,6 +132,12 @@ spec:
             mountPath: /var/lib/memgraph
           - name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
             mountPath: /var/log/memgraph
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
+          # Run by 'memgraph' user as specified in the Dockerfile
+
   volumeClaimTemplates:
     - metadata:
         name: memgraph-coordinator-{{ $coordinator.id }}-lib-storage

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -142,6 +142,12 @@ spec:
             mountPath: /var/lib/memgraph
           - name: memgraph-data-{{ $data.id }}-log-storage
             mountPath: /var/log/memgraph
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
+          # Run by 'memgraph' user as specified in the Dockerfile
+
   volumeClaimTemplates:
     - metadata:
         name: memgraph-data-{{ $data.id }}-lib-storage

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -92,23 +92,21 @@ spec:
         - name: memgraph-data-{{ $data.id }}-log-storage
           mountPath: /var/log/memgraph
         command: [ "/bin/sh","-c" ]
-        args: [ "chown -R memgraph:memgraph /var/log; chown -R memgraph:memgraph /var/lib" ]
+        args: [ "chown -R memgraph:memgraph /var/log/memgraph; chown -R memgraph:memgraph /var/lib/memgraph" ]
         securityContext:
-          privileged: true
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
+          runAsUser: 0 # Run as root
           capabilities:
-            drop: [ "all" ]
+            drop: [ "ALL" ]
             add: [ "CHOWN" ]
-          runAsUser: 0
-          runAsNonRoot: false
-    {{- if $.Values.sysctlInitContainer.enabled }}
+      {{- if $.Values.sysctlInitContainer.enabled }}
       - name: init-sysctl
         image: busybox
         command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
         securityContext:
           privileged: true
           runAsUser: 0
-        {{- end }}
+      {{- end }}
 
       containers:
       - name: memgraph-data
@@ -150,9 +148,7 @@ spec:
       spec:
         accessModes:
         - {{ $.Values.storage.libStorageAccessMode}}
-        {{- if $.Values.storage.libStorageClassName }}
         storageClassName: {{ $.Values.storage.libStorageClassName }}
-        {{- end }}
         resources:
           requests:
             storage: {{ $.Values.storage.libPVCSize }}
@@ -161,9 +157,7 @@ spec:
       spec:
         accessModes:
         - {{ $.Values.storage.logStorageAccessMode}}
-        {{- if $.Values.storage.logStorageClassName }}
         storageClassName: {{ $.Values.storage.logStorageClassName }}
-        {{- end }}
         resources:
           requests:
             storage: {{ $.Values.storage.logPVCSize }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -1,7 +1,6 @@
 image:
-  repository: memgraphacrha.azurecr.io/memgraph/memgraph
-    #tag: 2.22.0_23_8cb3c39c21
-  tag: 2.22.0_30_8a58da1477
+  repository: memgraph/memgraph
+  tag: 2.22.0
   pullPolicy: IfNotPresent
 
 env:
@@ -12,7 +11,7 @@ storage:
   libPVCSize: "1Gi"
   libStorageAccessMode: "ReadWriteOnce"
   # By default the name of the storage class isn't set which means that the default storage class will be used.
-  # If you set any name, the storage class with such name must exist.
+  # If you set any name, such storage class must exist.
   libStorageClassName:
   logPVCSize: "1Gi"
   logStorageAccessMode: "ReadWriteOnce"

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -1,6 +1,7 @@
 image:
-  repository: memgraph/memgraph
-  tag: 2.22.0
+  repository: memgraphacrha.azurecr.io/memgraph/memgraph
+    #tag: 2.22.0_23_8cb3c39c21
+  tag: 2.22.0_30_8a58da1477
   pullPolicy: IfNotPresent
 
 env:
@@ -11,7 +12,7 @@ storage:
   libPVCSize: "1Gi"
   libStorageAccessMode: "ReadWriteOnce"
   # By default the name of the storage class isn't set which means that the default storage class will be used.
-  # If you set any name, such storage class must exist.
+  # If you set any name, the storage class with such name must exist.
   libStorageClassName:
   logPVCSize: "1Gi"
   logStorageAccessMode: "ReadWriteOnce"


### PR DESCRIPTION
The PR deals with two things:
1. Improving securityContext of init container
Init container needs to be run with root permissions. fsGroup is not respected on all cloud platforms (tried on Azure AKS and didn't work) so the most general solution is using init container. Changing ownership of /var/log/memgraph and /var/lib/memgraph is enough. For that you don't need privileged access. runAsNonRoot field was unnecessary. Dropping all capabilities requires `ALL` instead of `all`.
2. Improving securityContext of memgraph-coordinator container
The user 'memgraph' runs memgraph-coordinator container. Improved version removes all capabilities from memgraph user and forbids privilege escalation.


