### PR TITLE
Use Memgraph 3.0.0

### DIFF
--- a/charts/memgraph-high-availability/Chart.yaml
+++ b/charts/memgraph-high-availability/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: memgraph-high-availability
 description: A Helm chart for Kubernetes with Memgraph High availabiliy capabilites
 
-version: 0.1.6
-appVersion: "2.22.0"
+version: 0.1.7
+appVersion: "3.0.0"
 
 type: application
 

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -82,7 +82,7 @@ spec:
         - name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
           mountPath: /var/log/memgraph
         command: [ "/bin/sh","-c" ]
-        args: [ "chown -R memgraph:memgraph /var/log/memgraph; chown -R memgraph:memgraph /var/lib/memgraph" ]
+        args: [ "chown -R memgraph:memgraph /var/log/memgraph /var/lib/memgraph || true" ]
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -92,7 +92,7 @@ spec:
         - name: memgraph-data-{{ $data.id }}-log-storage
           mountPath: /var/log/memgraph
         command: [ "/bin/sh","-c" ]
-        args: [ "chown -R memgraph:memgraph /var/log/memgraph; chown -R memgraph:memgraph /var/lib/memgraph" ]
+        args: [ "chown -R memgraph:memgraph /var/log/memgraph /var/lib/memgraph || true" ]
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: memgraph/memgraph
-  tag: 2.22.0
+  tag: 3.0.0
   pullPolicy: IfNotPresent
 
 env:

--- a/charts/memgraph/Chart.yaml
+++ b/charts/memgraph/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: memgraph
 home: https://memgraph.com/
 type: application
-version: 0.1.8
-appVersion: "2.22.0"
+version: 0.1.9
+appVersion: "3.0.0"
 description: MemgraphDB Helm Chart
 keywords:
 - graph

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -53,13 +53,13 @@ spec:
           args:
             - >
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-              chown -R memgraph:memgraph /var/lib/memgraph;
+              chown -R memgraph:memgraph /var/lib/memgraph || true;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createLogStorage }}
-              chown -R memgraph:memgraph /var/log/memgraph;
+              chown -R memgraph:memgraph /var/log/memgraph || true;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
-              chown -R memgraph:memgraph {{ .Values.persistentVolumeClaim.userMountPath }};
+              chown -R memgraph:memgraph {{ .Values.persistentVolumeClaim.userMountPath }} || true;
               {{- end }}
           securityContext:
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Bumps new version of memgraph chart and ha chart.
Fixes the bug with init container with permissions on lost+found directory. Lost+found directory can get created because of `fsck` program for data integrity. This program will put all corrupted files there and when chown is run, the command will fail because not even the root user has enough permissions to deal with lost+found directory.