### PR TITLE
Bump versions to 3.1

### DIFF
--- a/charts/memgraph-high-availability/Chart.yaml
+++ b/charts/memgraph-high-availability/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: memgraph-high-availability
 description: A Helm chart for Kubernetes with Memgraph High availabiliy capabilites
 
-version: 0.1.7
-appVersion: "3.0.0"
+version: 0.1.8
+appVersion: "3.1.0"
 
 type: application
 

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: memgraph/memgraph
-  tag: 3.0.0
+  tag: 3.1.0
   pullPolicy: IfNotPresent
 
 env:

--- a/charts/memgraph-lab/Chart.yaml
+++ b/charts/memgraph-lab/Chart.yaml
@@ -3,10 +3,10 @@ name: memgraph-lab
 home: https://memgraph.com/
 type: application
 # Chart version, should be incremented each time the chart changes, including appVersion.
-version: 0.1.5
+version: 0.1.6
 # Version number of the docker image memgraph/lab.
 # Use it with quotes.
-appVersion: "2.19.1"
+appVersion: "3.1.0"
 description: Memgraph Lab Helm Chart
 keywords:
 - graph

--- a/charts/memgraph/Chart.yaml
+++ b/charts/memgraph/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: memgraph
 home: https://memgraph.com/
 type: application
-version: 0.1.9
-appVersion: "3.0.0"
+version: 0.2.0
+appVersion: "3.1.0"
 description: MemgraphDB Helm Chart
 keywords:
 - graph


### PR DESCRIPTION
Upgrades Memgraph version to 3.1 for Lab, standalone and HA charts.