### PR TITLE
Bugfix: Use NuRaft server for probing coordinators

### DIFF
--- a/charts/memgraph-high-availability/Chart.yaml
+++ b/charts/memgraph-high-availability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memgraph-high-availability
 description: A Helm chart for Kubernetes with Memgraph High availabiliy capabilites
 
-version: 0.1.8
+version: 0.1.9
 appVersion: "3.1.0"
 
 type: application

--- a/charts/memgraph-high-availability/templates/_helpers.tpl
+++ b/charts/memgraph-high-availability/templates/_helpers.tpl
@@ -43,7 +43,7 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "container.readinessProbe" -}}
+{{- define "container.data.readinessProbe" -}}
 readinessProbe:
   tcpSocket:
     port: {{ .tcpSocket.port }}
@@ -53,7 +53,7 @@ readinessProbe:
 {{- end }}
 
 
-{{- define "container.livenessProbe" -}}
+{{- define "container.data.livenessProbe" -}}
 livenessProbe:
   tcpSocket:
     port: {{ .tcpSocket.port }}
@@ -63,7 +63,38 @@ livenessProbe:
 {{- end }}
 
 
-{{- define "container.startupProbe" -}}
+{{- define "container.data.startupProbe" -}}
+startupProbe:
+  tcpSocket:
+    port: {{ .tcpSocket.port }}
+  failureThreshold: {{ .failureThreshold }}
+  timeoutSeconds: {{ .timeoutSeconds }}
+  periodSeconds: {{ .periodSeconds }}
+{{- end }}
+
+
+
+{{- define "container.coordinators.readinessProbe" -}}
+readinessProbe:
+  tcpSocket:
+    port: {{ .tcpSocket.port }}
+  failureThreshold: {{ .failureThreshold }}
+  timeoutSeconds: {{ .timeoutSeconds }}
+  periodSeconds: {{ .periodSeconds }}
+{{- end }}
+
+
+{{- define "container.coordinators.livenessProbe" -}}
+livenessProbe:
+  tcpSocket:
+    port: {{ .tcpSocket.port }}
+  failureThreshold: {{ .failureThreshold }}
+  timeoutSeconds: {{ .timeoutSeconds }}
+  periodSeconds: {{ .periodSeconds }}
+{{- end }}
+
+
+{{- define "container.coordinators.startupProbe" -}}
 startupProbe:
   tcpSocket:
     port: {{ .tcpSocket.port }}

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -137,9 +137,9 @@ spec:
           capabilities:
             drop: [ "ALL" ]
           # Run by 'memgraph' user as specified in the Dockerfile
-        {{- include "container.readinessProbe" $.Values.container.readinessProbe | nindent 8 }}
-        {{- include "container.livenessProbe" $.Values.container.livenessProbe | nindent 8 }}
-        {{- include "container.startupProbe" $.Values.container.startupProbe | nindent 8 }}
+        {{- include "container.coordinators.readinessProbe" $.Values.container.coordinators.readinessProbe | nindent 8 }}
+        {{- include "container.coordinators.livenessProbe" $.Values.container.coordinators.livenessProbe | nindent 8 }}
+        {{- include "container.coordinators.startupProbe" $.Values.container.coordinators.startupProbe | nindent 8 }}
 
   volumeClaimTemplates:
     - metadata:

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -147,9 +147,9 @@ spec:
           capabilities:
             drop: [ "ALL" ]
           # Run by 'memgraph' user as specified in the Dockerfile
-        {{- include "container.readinessProbe" $.Values.container.readinessProbe | nindent 8 }}
-        {{- include "container.livenessProbe" $.Values.container.livenessProbe | nindent 8 }}
-        {{- include "container.startupProbe" $.Values.container.startupProbe | nindent 8 }}
+        {{- include "container.data.readinessProbe" $.Values.container.data.readinessProbe | nindent 8 }}
+        {{- include "container.data.livenessProbe" $.Values.container.data.livenessProbe | nindent 8 }}
+        {{- include "container.data.startupProbe" $.Values.container.data.startupProbe | nindent 8 }}
 
   volumeClaimTemplates:
     - metadata:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -18,10 +18,10 @@ storage:
   logStorageClassName:
 
 ports:
-  boltPort: 7687
+  boltPort: 7687   # If you change this value, change it also in probes definition
   managementPort: 10000
   replicationPort: 20000
-  coordinatorPort: 12000
+  coordinatorPort: 12000  # If you change this value, change it also in probes definition
 
 externalAccessConfig:
   dataInstance:
@@ -61,27 +61,45 @@ secrets:
   passwordKey: PASSWORD
 
 container:
-  # When a container is ready to be used. Disabled until startupProbe succeeds.
-  readinessProbe:
-    tcpSocket:
-      port: 7687
-    failureThreshold: 20
-    timeoutSeconds: 10
-    periodSeconds: 5
-  # To know when a container needs to be restarted.
-  # Disabled until startupProbe succeeds.
-  livenessProbe:
-    tcpSocket:
-      port: 7687
-    failureThreshold: 20
-    timeoutSeconds: 10
-    periodSeconds: 5
-  # When restoring Memgraph from a backup, it is important to give enough time app to start. Here, we set it to 2h by default.
-  startupProbe:
-    tcpSocket:
-      port: 7687
-    failureThreshold: 1440
-    periodSeconds: 5
+  data:
+    readinessProbe:
+      tcpSocket:
+        port: 7687  # If you change bolt port, change this also
+      failureThreshold: 20
+      timeoutSeconds: 10
+      periodSeconds: 5
+    livenessProbe:
+      tcpSocket:
+        port: 7687  # If you change bolt port, change this also
+      failureThreshold: 20
+      timeoutSeconds: 10
+      periodSeconds: 5
+    # When restoring Memgraph from a backup, it is important to give enough time app to start. Here, we set it to 2h by default.
+    startupProbe:
+      tcpSocket:
+        port: 7687  # If you change bolt port, change this also
+      failureThreshold: 1440
+      timeoutSeconds: 10
+      periodSeconds: 5
+  coordinators:
+    readinessProbe:
+      tcpSocket:
+        port: 12000  # If you change coordinator port, change this also
+      failureThreshold: 20
+      timeoutSeconds: 10
+      periodSeconds: 5
+    livenessProbe:
+      tcpSocket:
+        port: 12000  # If you change coordinator port, change this also
+      failureThreshold: 20
+      timeoutSeconds: 10
+      periodSeconds: 5
+    startupProbe:
+      tcpSocket:
+        port: 12000
+      failureThreshold: 20
+      timeoutSeconds: 10
+      periodSeconds: 5
 
 data:
 - id: "0"


### PR DESCRIPTION
For pinging coordinators, both bolt port and NuRaft port could be used. However, if bolt port is used there is an issue with the readiness probe which crashes coordinators.