### PR TITLE
Allow busybox image customization through values.yaml in charts/memgraph

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -102,7 +102,8 @@ spec:
             add: [ "CHOWN" ]
       {{- if $.Values.sysctlInitContainer.enabled }}
       - name: init-sysctl
-        image: busybox
+        image: "{{ $.Values.sysctlInitContainer.image.repository }}:{{ $.Values.sysctlInitContainer.image.tag }}"
+        imagePullPolicy: {{ $.Values.sysctlInitContainer.image.pullPolicy }}
         command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
         securityContext:
           privileged: true

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -112,7 +112,8 @@ spec:
             add: [ "CHOWN" ]
       {{- if $.Values.sysctlInitContainer.enabled }}
       - name: init-sysctl
-        image: busybox
+        image: "{{ $.Values.sysctlInitContainer.image.repository }}:{{ $.Values.sysctlInitContainer.image.tag }}"
+        imagePullPolicy: {{ $.Values.sysctlInitContainer.image.pullPolicy }}
         command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
         securityContext:
           privileged: true

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -74,6 +74,10 @@ affinity:
 sysctlInitContainer:
   enabled: true
   maxMapCount: 262144
+  image:
+    repository: library/busybox
+    tag: latest
+    pullPolicy: IfNotPresent
 
 # The explicit user and group setup is required because at the init container
 # time, there is not yet a user created. This seems fine because under both

--- a/charts/memgraph/README.md
+++ b/charts/memgraph/README.md
@@ -91,6 +91,9 @@ The following table lists the configurable parameters of the Memgraph chart and 
 | `storageClass.volumeBindingMode`             | Volume binding mode for the StorageClass                                                                                         | `Immediate`                            |
 | `sysctlInitContainer.enabled`                | Enable the init container to set sysctl parameters                                                                               | `true`                                 |
 | `sysctlInitContainer.maxMapCount`            | Value for `vm.max_map_count` to be set by the init container                                                                     | `262144`                               |
+| `sysctlInitContainer.image.repository`       | Busybox image repository                                                                                                         | `library/busybox`                      |
+| `sysctlInitContainer.image.tag`              | Specific tag for the Busybox Docker image                                                                                        | `latest`                               |
+| `sysctlInitContainer.image.pullPolicy`       | Image pull policy for busybox                                                                                                    | `IfNotPresent`                         |
 
 **Note:** It's often recommended not to specify default resources and leave it as a conscious choice for the user. If you want to specify resources, uncomment the following lines in your `values.yaml`, adjust them as necessary:
 

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -87,7 +87,8 @@ spec:
 
         {{- if .Values.sysctlInitContainer.enabled }}
         - name: init-sysctl
-          image: busybox
+          image: "{{ .Values.sysctlInitContainer.image.repository }}:{{ .Values.sysctlInitContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.sysctlInitContainer.image.pullPolicy }}
           command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ .Values.sysctlInitContainer.maxMapCount }}']
           securityContext:
             privileged: true

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -194,3 +194,7 @@ customQueryModules: []
 sysctlInitContainer:
   enabled: true
   maxMapCount: 262144
+  image:
+    repository: library/busybox
+    tag: latest
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Hi!

We can customize memgraph image but cannot customize busybox image which could be an issue for some users.

This fix allows busybox image customization through values.yaml in charts/memgraph.