### PR TITLE
Add support for headless services

### DIFF
--- a/charts/memgraph-high-availability/templates/services-coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/services-coordinators.yaml
@@ -5,7 +5,9 @@ kind: Service
 metadata:
   name: memgraph-coordinator-{{ .id }}
 spec:
-  type: ClusterIP
+  {{- if $.Values.headlessService.enabled }}
+  clusterIP: None
+  {{- end }}
   selector:
     app: memgraph-coordinator-{{ .id }}
   ports:

--- a/charts/memgraph-high-availability/templates/services-data.yaml
+++ b/charts/memgraph-high-availability/templates/services-data.yaml
@@ -5,7 +5,9 @@ kind: Service
 metadata:
   name: memgraph-data-{{ .id }}
 spec:
-  type: ClusterIP
+  {{- if $.Values.headlessService.enabled }}
+  clusterIP: None
+  {{- end }}
   selector:
     app: memgraph-data-{{ .id }}
   ports:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -32,7 +32,7 @@ externalAccessConfig:
     serviceType: "NodePort"
 
 headlessService:
-  enabled: false # If set to true, each data and coordinator instance will use headless service
+  enabled: false  # If set to true, each data and coordinator instance will use headless service
 
 # Affinity controls the scheduling of the memgraph-high-availability pods.
 # By default data pods will avoid being scheduled on the same node as other data pods,

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -31,6 +31,9 @@ externalAccessConfig:
   coordinator:
     serviceType: "NodePort"
 
+headlessService:
+  enabled: false # If set to true, each data and coordinator instance will use headless service
+
 # Affinity controls the scheduling of the memgraph-high-availability pods.
 # By default data pods will avoid being scheduled on the same node as other data pods,
 # and coordinator pods will avoid being scheduled on the same node as other coordinator pods.


### PR DESCRIPTION
Adds an option to connect coordinators and data instance inside K8s cluster using headless services. 