### PR TITLE
Add support for specifying resources in HA chart

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -140,6 +140,10 @@ spec:
         {{- include "container.coordinators.readinessProbe" $.Values.container.coordinators.readinessProbe | nindent 8 }}
         {{- include "container.coordinators.livenessProbe" $.Values.container.coordinators.livenessProbe | nindent 8 }}
         {{- include "container.coordinators.startupProbe" $.Values.container.coordinators.startupProbe | nindent 8 }}
+        {{- with $.Values.resources.coordinators }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 
   volumeClaimTemplates:
     - metadata:

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -150,6 +150,11 @@ spec:
         {{- include "container.data.readinessProbe" $.Values.container.data.readinessProbe | nindent 8 }}
         {{- include "container.data.livenessProbe" $.Values.container.data.livenessProbe | nindent 8 }}
         {{- include "container.data.startupProbe" $.Values.container.data.startupProbe | nindent 8 }}
+        {{- with $.Values.resources.data }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
 
   volumeClaimTemplates:
     - metadata:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -106,6 +106,10 @@ container:
       timeoutSeconds: 10
       periodSeconds: 5
 
+resources:
+  data: {}
+  coordinators: {}
+
 # If setting the --memory-limit flag under data instances, check that the amount of resources that a pod has been given is more than the actual memory limit you give to Memgraph
 # Setting the Memgraph's memory limit to more than the available resources can trigger pod eviction and restarts before Memgraph can make a query exception and continue running
 # the pod.


### PR DESCRIPTION
HA chart now supports adding resources block. The change is unbreaking in a sense that `helm upgrade` can be used.

Docs PR: https://github.com/memgraph/documentation/pull/1247