### PR TITLE
Add annotations support for external access services in HA chart

### DIFF
--- a/charts/memgraph-high-availability/templates/services-coordinators-external.yaml
+++ b/charts/memgraph-high-availability/templates/services-coordinators-external.yaml
@@ -10,6 +10,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: coordinators
+  {{- with $.Values.externalAccessConfig.coordinator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: LoadBalancer
   selector:
@@ -26,6 +30,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: memgraph-coordinator-{{ .id }}-external
+  {{- with $.Values.externalAccessConfig.coordinator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{ if eq $.Values.externalAccessConfig.coordinator.serviceType "LoadBalancer"}}
   type: LoadBalancer

--- a/charts/memgraph-high-availability/templates/services-data-external.yaml
+++ b/charts/memgraph-high-availability/templates/services-data-external.yaml
@@ -13,6 +13,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: memgraph-data-{{ .id }}-external
+  {{- with $.Values.externalAccessConfig.dataInstance.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{ if eq $.Values.externalAccessConfig.dataInstance.serviceType "NodePort"}}
   type: NodePort

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -28,8 +28,10 @@ ports:
 externalAccessConfig:
   dataInstance:
     serviceType: "NodePort"
+    annotations: {}
   coordinator:
     serviceType: "NodePort"
+    annotations: {}
 
 headlessService:
   enabled: false  # If set to true, each data and coordinator instance will use headless service


### PR DESCRIPTION
External access services like NodePort and LoadBalancers can be configured using annotations specifies in the values.yaml file