### PR TITLE
Add support for service labels in standalone chart

### DIFF
--- a/charts/memgraph/templates/service.yaml
+++ b/charts/memgraph/templates/service.yaml
@@ -2,8 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "memgraph.fullname" . }}
+  {{- with .Values.service.labels }}
   labels:
-    {{- include "memgraph.labels" . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -46,6 +46,7 @@ service:
   enableHttpMonitoring: false
   httpPortMonitoring: 9091
   annotations: {}
+  labels: {}
 
 persistentVolumeClaim:
   ## createStoragePVC `true` will create for each statefulset server a Persistant Volume Claim


### PR DESCRIPTION
ClusterIP service inside the standalone chart can now specify labels from values.yaml file.