### PR TITLE
Add support for starting HA chart without external network configuration

### DIFF
--- a/charts/memgraph-high-availability/templates/services-coordinators-external.yaml
+++ b/charts/memgraph-high-availability/templates/services-coordinators-external.yaml
@@ -1,11 +1,11 @@
-{{- $validCoordServices := list "CommonLoadBalancer" "LoadBalancer" "NodePort" "IngressNginx" }}
+{{- $validCoordServices := list "" "CommonLoadBalancer" "LoadBalancer" "NodePort" "IngressNginx" }}
 {{- if not (has .Values.externalAccessConfig.coordinator.serviceType $validCoordServices) }}
-{{- fail "Invalid environment value for externalAccessConfig.coordinator.serviceType. Use 'CommonLoadBalancer', 'LoadBalancer', 'NodePort' or 'IngressNginx'."}}
+  {{- fail "Invalid value for externalAccessConfig.coordinator.serviceType. Use '', 'CommonLoadBalancer', 'LoadBalancer', 'NodePort' or 'IngressNginx'." }}
 {{- end }}
 
-{{ if eq $.Values.externalAccessConfig.coordinator.serviceType "IngressNginx"}}
-# Placeholder
-{{ else if eq $.Values.externalAccessConfig.coordinator.serviceType "CommonLoadBalancer"}}
+{{- if or (eq $.Values.externalAccessConfig.coordinator.serviceType "IngressNginx") (eq $.Values.externalAccessConfig.coordinator.serviceType "") }}
+  {{- /* No external service rendered for IngressNginx or empty string */}}
+{{- else if eq $.Values.externalAccessConfig.coordinator.serviceType "CommonLoadBalancer" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,8 +23,8 @@ spec:
       name: tcp-bolt-port
       port: {{ $.Values.ports.boltPort }}
       targetPort: {{ $.Values.ports.boltPort }}
-{{ else }}
-{{- range .Values.coordinators }}
+{{- else }}
+  {{- range .Values.coordinators }}
 ---
 apiVersion: v1
 kind: Service
@@ -35,11 +35,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{ if eq $.Values.externalAccessConfig.coordinator.serviceType "LoadBalancer"}}
+  {{- if eq $.Values.externalAccessConfig.coordinator.serviceType "LoadBalancer" }}
   type: LoadBalancer
-{{ else }}
+  {{- else if eq $.Values.externalAccessConfig.coordinator.serviceType "NodePort" }}
   type: NodePort
-{{ end }}
+  {{- end }}
   selector:
     app: memgraph-coordinator-{{ .id }}
   ports:
@@ -47,5 +47,5 @@ spec:
       name: tcp-bolt-port
       port: {{ $.Values.ports.boltPort }}
       targetPort: {{ $.Values.ports.boltPort }}
+  {{- end }}
 {{- end }}
-{{ end}}

--- a/charts/memgraph-high-availability/templates/services-data-external.yaml
+++ b/charts/memgraph-high-availability/templates/services-data-external.yaml
@@ -1,13 +1,12 @@
-{{- $validDataServices := list "LoadBalancer" "NodePort" "IngressNginx" }}
+{{- $validDataServices := list "" "LoadBalancer" "NodePort" "IngressNginx" }}
 {{- if not (has .Values.externalAccessConfig.dataInstance.serviceType $validDataServices) }}
-{{- fail "Invalid environment value for externalAccessConfig.dataInstance.serviceType. Use 'LoadBalancer', 'NodePort' or 'IngressNginx'."}}
+  {{- fail "Invalid value for externalAccessConfig.dataInstance.serviceType. Use '', 'LoadBalancer', 'NodePort', or 'IngressNginx'." }}
 {{- end }}
 
-
-{{ if eq $.Values.externalAccessConfig.dataInstance.serviceType "IngressNginx"}}
-# Placeholder
-{{ else }}
-{{- range .Values.data }}
+{{- if or (eq $.Values.externalAccessConfig.dataInstance.serviceType "IngressNginx") (eq $.Values.externalAccessConfig.dataInstance.serviceType "") }}
+  {{- /* No external service rendered for IngressNginx or empty string */}}
+{{- else }}
+  {{- range .Values.data }}
 ---
 apiVersion: v1
 kind: Service
@@ -18,11 +17,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{ if eq $.Values.externalAccessConfig.dataInstance.serviceType "NodePort"}}
+  {{- if eq $.Values.externalAccessConfig.dataInstance.serviceType "NodePort" }}
   type: NodePort
-{{ else }}
+  {{- else if eq $.Values.externalAccessConfig.dataInstance.serviceType "LoadBalancer" }}
   type: LoadBalancer
-{{ end }}
+  {{- end }}
   selector:
     app: memgraph-data-{{ .id }}
   ports:
@@ -30,5 +29,5 @@ spec:
       name: tcp-bolt-port
       port: {{ $.Values.ports.boltPort }}
       targetPort: {{ $.Values.ports.boltPort }}
+  {{- end }}
 {{- end }}
-{{ end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -27,10 +27,10 @@ ports:
 
 externalAccessConfig:
   dataInstance:
-    serviceType: "NodePort"
+    serviceType: ""
     annotations: {}
   coordinator:
-    serviceType: "NodePort"
+    serviceType: ""
     annotations: {}
 
 headlessService:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -27,9 +27,11 @@ ports:
 
 externalAccessConfig:
   dataInstance:
+    # Empty = no external access service will be created
     serviceType: ""
     annotations: {}
   coordinator:
+    # Empty = no external access service will be created
     serviceType: ""
     annotations: {}
 


### PR DESCRIPTION
HA chart can now be started without external access service like LoadBalancer, NodePort or IngressNginx