### PR TITLE
Separate PVC options for coordinators and data instances in HA chart

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,2 @@
+.git/
+.gitignore

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -4,6 +4,8 @@ owners: # (optional, used to claim repository ownership)
     email: supe.katarina@gmail.com
   - name: antejavor
     email: javor.ante@gmail.com
+  - name: andiskrgat
+    email: andi.skrgat@memgraph.io
 # ignore: # (optional, packages that should not be indexed by Artifact Hub)
 #   - name: package1
 #   - name: package2 # Exact match

--- a/charts/memgraph-high-availability/aws/README.md
+++ b/charts/memgraph-high-availability/aws/README.md
@@ -86,8 +86,10 @@ We can now install Memgraph HA chart using the following command:
 helm install mem-ha-test ./charts/memgraph-high-availability --set \
 env.MEMGRAPH_ENTERPRISE_LICENSE=<YOUR_LICENSE>, \
 env.MEMGRAPH_ORGANIZATION_NAME=<YOUR_ORGANIZATION_NAME>, \
-storage.libStorageClassName=gp2, \
-storage.logStorageClassName=gp2, \
+storage.coordinators.libStorageClassName=gp2, \
+storage.data.libStorageClassName=gp2, \
+storage.coordinators.logStorageClassName=gp2, \
+storage.data.logStorageClassName=gp2, \
 affinity.nodeSelection=true, \
 externalAccessConfig.dataInstance.serviceType=NodePort, \
 externalAccessConfig.coordinator.serviceType=NodePort

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -150,20 +150,20 @@ spec:
         name: memgraph-coordinator-{{ $coordinator.id }}-lib-storage
       spec:
         accessModes:
-        - {{ $.Values.storage.libStorageAccessMode}}
-        storageClassName: {{ $.Values.storage.libStorageClassName }}
+        - {{ $.Values.storage.coordinators.libStorageAccessMode }}
+        storageClassName: {{ $.Values.storage.coordinators.libStorageClassName }}
         resources:
           requests:
-            storage: {{ $.Values.storage.libPVCSize }}
+            storage: {{ $.Values.storage.coordinators.libPVCSize }}
 
     - metadata:
         name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
       spec:
         accessModes:
-        - {{ $.Values.storage.logStorageAccessMode}}
-        storageClassName: {{ $.Values.storage.logStorageClassName }}
+        - {{ $.Values.storage.coordinators.logStorageAccessMode }}
+        storageClassName: {{ $.Values.storage.coordinators.logStorageClassName }}
         resources:
           requests:
-            storage: {{ $.Values.storage.logPVCSize }}
+            storage: {{ $.Values.storage.coordinators.logPVCSize }}
 ---
 {{- end }}

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -161,20 +161,20 @@ spec:
         name: memgraph-data-{{ $data.id }}-lib-storage
       spec:
         accessModes:
-        - {{ $.Values.storage.libStorageAccessMode}}
-        storageClassName: {{ $.Values.storage.libStorageClassName }}
+        - {{ $.Values.storage.data.libStorageAccessMode }}
+        storageClassName: {{ $.Values.storage.data.libStorageClassName }}
         resources:
           requests:
-            storage: {{ $.Values.storage.libPVCSize }}
+            storage: {{ $.Values.storage.data.libPVCSize }}
     - metadata:
         name: memgraph-data-{{ $data.id }}-log-storage
       spec:
         accessModes:
-        - {{ $.Values.storage.logStorageAccessMode}}
-        storageClassName: {{ $.Values.storage.logStorageClassName }}
+        - {{ $.Values.storage.data.logStorageAccessMode }}
+        storageClassName: {{ $.Values.storage.data.logStorageClassName }}
         resources:
           requests:
-            storage: {{ $.Values.storage.logPVCSize }}
+            storage: {{ $.Values.storage.data.logPVCSize }}
 
 ---
 {{- end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -10,14 +10,24 @@ env:
   MEMGRAPH_ORGANIZATION_NAME: "<your-organization-name>"
 
 storage:
-  libPVCSize: "1Gi"
-  libStorageAccessMode: "ReadWriteOnce"
-  # By default the name of the storage class isn't set which means that the default storage class will be used.
-  # If you set any name, such storage class must exist.
-  libStorageClassName:
-  logPVCSize: "1Gi"
-  logStorageAccessMode: "ReadWriteOnce"
-  logStorageClassName:
+  data:
+    libPVCSize: "1Gi"
+    libStorageAccessMode: "ReadWriteOnce"
+    # By default the name of the storage class isn't set which means that the default storage class will be used.
+    # If you set any name, such storage class must exist.
+    libStorageClassName:
+    logPVCSize: "1Gi"
+    logStorageAccessMode: "ReadWriteOnce"
+    logStorageClassName:
+  coordinators:
+    libPVCSize: "1Gi"
+    libStorageAccessMode: "ReadWriteOnce"
+    # By default the name of the storage class isn't set which means that the default storage class will be used.
+    # If you set any name, such storage class must exist.
+    libStorageClassName:
+    logPVCSize: "1Gi"
+    logStorageAccessMode: "ReadWriteOnce"
+    logStorageClassName:
 
 ports:
   boltPort: 7687   # If you change this value, change it also in probes definition


### PR DESCRIPTION
Storage options can now be specified separately for coordinators and data instances. 