### PR TITLE
Add support for Memgraph Prometheus exporter in the K8s

### DIFF
--- a/charts/memgraph-high-availability/Chart.lock
+++ b/charts/memgraph-high-availability/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: kube-prometheus-stack
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 71.0.0
-digest: sha256:c17b621f3de481fb0e216200665bfbbba357558d0dc2ec6c937ee60d6ecf0ee7
-generated: "2025-04-30T13:26:48.694701+02:00"

--- a/charts/memgraph-high-availability/Chart.lock
+++ b/charts/memgraph-high-availability/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: prometheus
+- name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 25.19.0
-digest: sha256:d9f78a4fbc226af5363191cb84d1883caa7f3e7f3a6a017ce4096f0810df2dc1
-generated: "2025-04-23T08:19:30.162455+02:00"
+  version: 71.0.0
+digest: sha256:c17b621f3de481fb0e216200665bfbbba357558d0dc2ec6c937ee60d6ecf0ee7
+generated: "2025-04-30T13:26:48.694701+02:00"

--- a/charts/memgraph-high-availability/Chart.yaml
+++ b/charts/memgraph-high-availability/Chart.yaml
@@ -23,12 +23,6 @@ sources:
 - "https://github.com/memgraph/memgraph"
 - "https://github.com/memgraph/helm-charts"
 
-dependencies:
-  - name: prometheus
-    version: "25.19.0"
-    repository: "https://prometheus-community.github.io/helm-charts"
-    condition: prometheus.enabled
-
 maintainers:
 - name: Memgraph
   email: tech@memgraph.com

--- a/charts/memgraph-high-availability/templates/mg-exporter.yaml
+++ b/charts/memgraph-high-availability/templates/mg-exporter.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mg-exporter-config
+data:
+  ha_config.yaml: |
+    exporter:
+      port: 9115  # TODO: (andi) abstract
+      pull_frequency_seconds: 5  # TODO: (andi) abstract
+    instances:
+      # TODO: (andi) Needs to be added to the section about upgrading, try to templatize
+      - name: coord1
+        url:  http://memgraph-coordinator-1.default.svc.cluster.local
+        port: 9091
+        type: coordinator
+      - name: coord2
+        url:  http://memgraph-coordinator-2.default.svc.cluster.local
+        port: 9091
+        type: coordinator
+      - name: coord3
+        url:  http://memgraph-coordinator-3.default.svc.cluster.local
+        port: 9091
+        type: coordinator
+      - name: data1
+        url:  http://memgraph-data-0.default.svc.cluster.local
+        port: 9091
+        type: data_instance
+      - name: data2
+        url:  http://memgraph-data-1.default.svc.cluster.local
+        port: 9091
+        type: data_instance
+---
+apiVersion: apps/v1
+kind: Deployment # Because I don't need stable pod names or persistent storage
+metadata:
+  name: mg-exporter
+  labels:
+    app: mg-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mg-exporter
+  template:
+    metadata:
+      labels:
+        app: mg-exporter
+    spec:
+      containers:
+        - name: exporter
+        # image: memgraph/prometheus-exporter:0.2.0
+      image: memgraphcrha.azurecr.io/memgraph/mg-exporter:0.2.2  # TODO: (andi) Change to official version
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/mg-exporter/ha_config.yaml
+              subPath: ha_config.yaml
+          ports:
+            - containerPort: 9115 # TODO: (andi) Abstract port configuration
+          env:
+            - name: DEPLOYMENT_TYPE
+              value: HA  # HA stands for high availability
+            - name: CONFIG_FILE
+              value: /etc/mg-exporter/ha_config.yaml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: mg-exporter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mg-exporter
+  labels:
+    app: mg-exporter
+spec:
+  selector:
+    app: mg-exporter
+  ports:
+    - protocol: TCP
+      name: tcp-metrics-port
+      port: 9115 # TODO: (andi) Abstract port configuration
+      targetPort: 9115 # TODO: (andi) Abstract port configuration
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mg-exporter
+  labels:
+    release: prometheus-stack  # must match your release name, abstract it
+spec:
+  selector:
+    matchLabels:
+      app: mg-exporter
+  endpoints:
+    - port: tcp-metrics-port  # must be the same as on the top
+      interval: 15s  # TODO: (andi) Abstract
+  namespaceSelector:
+    matchNames:
+      - default  # TODO: (andi) Abstract and this whether this should be in default. This refers to where our service exposing the exporter is
+
+      # This needs to be added TODO: (andi) to the values.yaml
+# prometheus.prometheusSpec.serviceMonitorNamespaceSelector:
+#  any: true

--- a/charts/memgraph-high-availability/templates/mg-exporter.yaml
+++ b/charts/memgraph-high-availability/templates/mg-exporter.yaml
@@ -1,12 +1,14 @@
+{{- if $.Values.prometheus.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: mg-exporter-config
+  namespace: {{ $.Values.prometheus.namespace }}
 data:
   ha_config.yaml: |
     exporter:
-      port: 9115  # TODO: (andi) abstract
-      pull_frequency_seconds: 5  # TODO: (andi) abstract
+      port: {{ $.Values.prometheus.memgraphExporter.port }}
+      pull_frequency_seconds: {{ $.Values.prometheus.memgraphExporter.pullFrequencySeconds }}
     instances:
       # TODO: (andi) Needs to be added to the section about upgrading, try to templatize
       - name: coord1
@@ -34,6 +36,7 @@ apiVersion: apps/v1
 kind: Deployment # Because I don't need stable pod names or persistent storage
 metadata:
   name: mg-exporter
+  namespace: {{ $.Values.prometheus.namespace }}
   labels:
     app: mg-exporter
 spec:
@@ -48,14 +51,13 @@ spec:
     spec:
       containers:
         - name: exporter
-        # image: memgraph/prometheus-exporter:0.2.0
-      image: memgraphcrha.azurecr.io/memgraph/mg-exporter:0.2.2  # TODO: (andi) Change to official version
+          image: {{ $.Values.prometheus.memgraphExporter.repository }}:{{ $.Values.prometheus.memgraphExporter.tag }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/mg-exporter/ha_config.yaml
               subPath: ha_config.yaml
           ports:
-            - containerPort: 9115 # TODO: (andi) Abstract port configuration
+            - containerPort: {{ $.Values.prometheus.memgraphExporter.port }}
           env:
             - name: DEPLOYMENT_TYPE
               value: HA  # HA stands for high availability
@@ -70,6 +72,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mg-exporter
+  namespace: {{ $.Values.prometheus.namespace }}
   labels:
     app: mg-exporter
 spec:
@@ -78,26 +81,24 @@ spec:
   ports:
     - protocol: TCP
       name: tcp-metrics-port
-      port: 9115 # TODO: (andi) Abstract port configuration
-      targetPort: 9115 # TODO: (andi) Abstract port configuration
+      port: {{ $.Values.prometheus.memgraphExporter.port }}
+      targetPort: {{ $.Values.prometheus.memgraphExporter.port }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: mg-exporter
+  namespace: {{ $.Values.prometheus.namespace }}
   labels:
-    release: prometheus-stack  # must match your release name, abstract it
+    release: {{ $.Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
 spec:
   selector:
     matchLabels:
       app: mg-exporter
   endpoints:
     - port: tcp-metrics-port  # must be the same as on the top
-      interval: 15s  # TODO: (andi) Abstract
+      interval: {{ $.Values.prometheus.serviceMonitor.interval }}
   namespaceSelector:
     matchNames:
-      - default  # TODO: (andi) Abstract and this whether this should be in default. This refers to where our service exposing the exporter is
-
-      # This needs to be added TODO: (andi) to the values.yaml
-# prometheus.prometheusSpec.serviceMonitorNamespaceSelector:
-#  any: true
+      - {{ $.Values.prometheus.namespace }} # This refers to where our service exposing the exporter is located
+{{- end }}

--- a/charts/memgraph-high-availability/templates/mg-exporter.yaml
+++ b/charts/memgraph-high-availability/templates/mg-exporter.yaml
@@ -33,7 +33,7 @@ data:
         type: data_instance
 ---
 apiVersion: apps/v1
-kind: Deployment # Because I don't need stable pod names or persistent storage
+kind: Deployment
 metadata:
   name: mg-exporter
   namespace: {{ $.Values.prometheus.namespace }}
@@ -96,7 +96,7 @@ spec:
     matchLabels:
       app: mg-exporter
   endpoints:
-    - port: tcp-metrics-port  # must be the same as on the top
+    - port: tcp-metrics-port  # must be the same as the service port name
       interval: {{ $.Values.prometheus.serviceMonitor.interval }}
   namespaceSelector:
     matchNames:

--- a/charts/memgraph-high-availability/templates/services-coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/services-coordinators.yaml
@@ -23,8 +23,11 @@ spec:
       name: tcp-management-port
       port: {{ $.Values.ports.managementPort }}
       targetPort: {{ $.Values.ports.managementPort }}
+    {{- if $.Values.prometheus.enabled }}
     - protocol: TCP
       name: tcp-metrics-port
       port: 9091
       targetPort: 9091
+    {{- end }}
+
 {{- end }}

--- a/charts/memgraph-high-availability/templates/services-coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/services-coordinators.yaml
@@ -23,4 +23,8 @@ spec:
       name: tcp-management-port
       port: {{ $.Values.ports.managementPort }}
       targetPort: {{ $.Values.ports.managementPort }}
+    - protocol: TCP
+      name: tcp-metrics-port
+      port: 9091
+      targetPort: 9091
 {{- end }}

--- a/charts/memgraph-high-availability/templates/services-data.yaml
+++ b/charts/memgraph-high-availability/templates/services-data.yaml
@@ -23,4 +23,8 @@ spec:
       name: tcp-replication-port
       port: {{ $.Values.ports.replicationPort }}
       targetPort: {{ $.Values.ports.replicationPort }}
+    - protocol: TCP
+      name: tcp-metrics-port
+      port: 9091
+      targetPort: 9091
 {{- end }}

--- a/charts/memgraph-high-availability/templates/services-data.yaml
+++ b/charts/memgraph-high-availability/templates/services-data.yaml
@@ -23,8 +23,10 @@ spec:
       name: tcp-replication-port
       port: {{ $.Values.ports.replicationPort }}
       targetPort: {{ $.Values.ports.replicationPort }}
+    {{- if $.Values.prometheus.enabled }}
     - protocol: TCP
       name: tcp-metrics-port
       port: 9091
       targetPort: 9091
+    {{- end }}
 {{- end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -126,6 +126,18 @@ resources:
   data: {}
   coordinators: {}
 
+prometheus:
+  enabled: false
+  namespace: monitoring  # Namespace where K8s resources from mg-exporter.yaml will be installed and where your kube-prometheus-stack chart is installed
+  memgraphExporter:
+    port: 9115
+    pullFrequencySeconds: 5
+    repository: memgraph/mg-exporter
+    tag: 0.2.1
+  serviceMonitor:
+    kubePrometheusStackReleaseName: kube-prometheus-stack
+    interval: 15s
+
 # If setting the --memory-limit flag under data instances, check that the amount of resources that a pod has been given is more than the actual memory limit you give to Memgraph
 # Setting the Memgraph's memory limit to more than the available resources can trigger pod eviction and restarts before Memgraph can make a query exception and continue running
 # the pod.

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -126,12 +126,6 @@ resources:
   data: {}
   coordinators: {}
 
-prometheus:
-  enabled: false
-  server:
-    service:
-      type: LoadBalancer
-
 # If setting the --memory-limit flag under data instances, check that the amount of resources that a pod has been given is more than the actual memory limit you give to Memgraph
 # Setting the Memgraph's memory limit to more than the available resources can trigger pod eviction and restarts before Memgraph can make a query exception and continue running
 # the pod.


### PR DESCRIPTION
HA chart now also supports integration with Memgraph's Prometheus exporter.

Docs PR: https://github.com/memgraph/documentation/pull/1275