### PR TITLE
Add core dumps PVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,11 @@ Contributions are welcome! If you have any improvements, bug fixes, or new chart
   </a>
 </p>
 
+## Debugging Memgraph Pods
+
+Find more details under [Debugging Running
+Pods](https://memgraph.com/docs/database-management/debugging#debugging-running-pods)
+documentation section.
+
 ## License
 This repository is licensed under the [Apache 2.0 License](https://github.com/memgraph/helm-charts/blob/main/LICENSE).

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -82,7 +82,13 @@ spec:
         - name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
           mountPath: /var/log/memgraph
         command: [ "/bin/sh","-c" ]
-        args: [ "chown -R memgraph:memgraph /var/log/memgraph /var/lib/memgraph || true" ]
+        # The permissions have to be explicitly adjusted because under some k8s
+        # environments permissions set under
+        # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
+        # get overwritten. Sometimes, PVC are created using new partitions ->
+        # lost+found directory should not / can't change its permissions so it
+        # has to be excluded.
+        args: [ "chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -88,7 +88,12 @@ spec:
         # get overwritten. Sometimes, PVC are created using new partitions ->
         # lost+found directory should not / can't change its permissions so it
         # has to be excluded.
-        args: [ "chown -R {{ $.Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
+        args:
+          - >
+            cd /var/log/memgraph;
+            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+            cd /var/lib/memgraph;
+            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -88,7 +88,7 @@ spec:
         # get overwritten. Sometimes, PVC are created using new partitions ->
         # lost+found directory should not / can't change its permissions so it
         # has to be excluded.
-        args: [ "chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
+        args: [ "chown -R {{ $.Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -86,14 +86,14 @@ spec:
         # environments permissions set under
         # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
         # get overwritten. Sometimes, PVC are created using new partitions ->
-        # lost+found directory should not / can't change its permissions so it
-        # has to be excluded.
+        # lost+found directory should not change its permissions so it has to
+        # be excluded.
         args:
           - >
             cd /var/log/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             cd /var/lib/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -92,7 +92,13 @@ spec:
         - name: memgraph-data-{{ $data.id }}-log-storage
           mountPath: /var/log/memgraph
         command: [ "/bin/sh","-c" ]
-        args: [ "chown -R memgraph:memgraph /var/log/memgraph /var/lib/memgraph || true" ]
+        # The permissions have to be explicitly adjusted because under some k8s
+        # environments permissions set under
+        # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
+        # get overwritten. Sometimes, PVC are created using new partitions ->
+        # lost+found directory should not / can't change its permissions so it
+        # has to be excluded.
+        args: [ "chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -98,7 +98,12 @@ spec:
         # get overwritten. Sometimes, PVC are created using new partitions ->
         # lost+found directory should not / can't change its permissions so it
         # has to be excluded.
-        args: [ "chown -R {{ $.Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
+        args:
+          - >
+            cd /var/log/memgraph;
+            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+            cd /var/lib/memgraph;
+            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -96,14 +96,14 @@ spec:
         # environments permissions set under
         # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
         # get overwritten. Sometimes, PVC are created using new partitions ->
-        # lost+found directory should not / can't change its permissions so it
-        # has to be excluded.
+        # lost+found directory should not change its permissions so it has to
+        # be excluded.
         args:
           - >
             cd /var/log/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             cd /var/lib/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -98,7 +98,7 @@ spec:
         # get overwritten. Sometimes, PVC are created using new partitions ->
         # lost+found directory should not / can't change its permissions so it
         # has to be excluded.
-        args: [ "chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
+        args: [ "chown -R {{ $.Values.memgraphUserGroupId }} /var/log/memgraph /var/lib/memgraph || true" ]
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 0 # Run as root

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -75,6 +75,12 @@ sysctlInitContainer:
   enabled: true
   maxMapCount: 262144
 
+# The explicit user and group setup is required because at the init container
+# time, there is not yet a user created. This seems fine because under both
+# Memgraph and Mage images we actually hard-code the user and group id. The
+# config is used to chown user storage and core dumps claims' month paths.
+memgraphUserGroupId: "100:101"
+
 secrets:
   enabled: false
   name: memgraph-secrets

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
           # .lost+found directory should not / can't change its permissions so
           # it has to be excluded.
           args:
-            - > 
+            - >
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}
               find /var/lib/memgraph -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -56,21 +56,16 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - >
-              {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-              chown -R memgraph:memgraph /var/lib/memgraph || true;
-              {{- end }}
-              {{- if .Values.persistentVolumeClaim.createLogStorage }}
-              chown -R memgraph:memgraph /var/log/memgraph || true;
-              {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
-              chown -R memgraph:memgraph {{ .Values.persistentVolumeClaim.userMountPath }} || true;
+              mkdir -p {{ .Values.persistentVolumeClaim.createUserClaim }};
+              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }};
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-              mkdir -p {{ .Values.persistentVolumeClaim.coreDumpsMountPath }}
-              chown -R memgraph:memgraph {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
+              mkdir -p {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
+              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
               {{- end }}
           securityContext:
-            readOnlyRootFilesystem: true # TODO(gitbuda): The above chown commands fail...
+            readOnlyRootFilesystem: true
             runAsUser: 0
             capabilities:
               drop: ["ALL"]
@@ -88,7 +83,11 @@ spec:
         {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
         - name: init-core-dumps
           image: busybox
-          command: ['sh', '-c', 'echo "{{ .Values.persistentVolumeClaim.coreDumpsMountPath }}/core.%e.%p" > /proc/sys/kernel/core_pattern']
+          command: ['/bin/sh', '-c']
+          args:
+            - >
+              echo "{{ .Values.persistentVolumeClaim.coreDumpsMountPath }}/core.%e.%p.%t.%s" > /proc/sys/kernel/core_pattern;
+              echo 0 | tee /proc/sys/kernel/yama/ptrace_scope;
           securityContext:
             privileged: true
             runAsUser: 0

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -63,16 +63,20 @@ spec:
           args:
             - >
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-              chown -R {{ .Values.memgraphUserGroupId }} /var/lib/memgraph || true;
+              cd /var/lib/memgraph;
+              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createLogStorage }}
-              chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph || true;
+              cd /var/log/memgraph;
+              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
-              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }} || true;
+              cd {{ .Values.persistentVolumeClaim.userMountPath }};
+              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
+              cd {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
+              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
           securityContext:
             readOnlyRootFilesystem: true

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -55,14 +55,18 @@ spec:
           {{- end }}
           command: ["/bin/sh", "-c"]
           args:
-            - >
+            - > # Document or change the || true.
+              {{- if .Values.persistentVolumeClaim.createStorageClaim }}
+              chown -R {{ .Values.memgraphUserGroupId }} /var/lib/memgraph || true;
+              {{- end }}
+              {{- if .Values.persistentVolumeClaim.createLogStorage }}
+              chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph || true;
+              {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
-              mkdir -p {{ .Values.persistentVolumeClaim.createUserClaim }};
-              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }};
+              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }} || true;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-              mkdir -p {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
-              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
+              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
               {{- end }}
           securityContext:
             readOnlyRootFilesystem: true

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -86,8 +86,8 @@ spec:
           command: ['/bin/sh', '-c']
           args:
             - >
-              echo "{{ .Values.persistentVolumeClaim.coreDumpsMountPath }}/core.%e.%p.%t.%s" > /proc/sys/kernel/core_pattern;
-              echo 0 | tee /proc/sys/kernel/yama/ptrace_scope;
+              echo '{{ .Values.persistentVolumeClaim.coreDumpsMountPath }}/core.%e.%p.%t.%s' | tee /proc/sys/kernel/core_pattern;
+              if [ -d /proc/sys/kernel/yama ]; then echo '0' | tee /proc/sys/kernel/yama/ptrace_scope; fi
           securityContext:
             privileged: true
             runAsUser: 0

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -58,8 +58,8 @@ spec:
           # k8s environments permissions set under
           # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
           # get overwritten. Sometimes, PVC are created using new partitions ->
-          # lost+found directory should not / can't change its permissions so
-          # it has to be excluded.
+          # lost+found directory should not change its permissions so it has to
+          # be excluded.
           args:
             - >
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
       annotations:
         {{- toYaml . | nindent 4 }}
       {{- end }}
+
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccount: {{ include "memgraph.serviceAccountName" . }}
@@ -48,7 +49,10 @@ spec:
             - name: {{ include "memgraph.fullname" . }}-user-storage
               mountPath: {{ .Values.persistentVolumeClaim.userMountPath }}
           {{- end }}
-
+          {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
+            - name: {{ include "memgraph.fullname" . }}-core-dumps-storage
+              mountPath: {{ .Values.persistentVolumeClaim.coreDumpsMountPath }}
+          {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - >
@@ -61,12 +65,17 @@ spec:
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
               chown -R memgraph:memgraph {{ .Values.persistentVolumeClaim.userMountPath }} || true;
               {{- end }}
+              {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
+              mkdir -p {{ .Values.persistentVolumeClaim.coreDumpsMountPath }}
+              chown -R memgraph:memgraph {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
+              {{- end }}
           securityContext:
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: true # TODO(gitbuda): The above chown commands fail...
             runAsUser: 0
             capabilities:
               drop: ["ALL"]
               add: ["CHOWN"]
+
         {{- if .Values.sysctlInitContainer.enabled }}
         - name: init-sysctl
           image: busybox
@@ -74,7 +83,17 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
-          {{- end }}
+        {{- end }}
+
+        {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
+        - name: init-core-dumps
+          image: busybox
+          command: ['sh', '-c', 'echo "{{ .Values.persistentVolumeClaim.coreDumpsMountPath }}/core.%e.%p" > /proc/sys/kernel/core_pattern']
+          securityContext:
+            privileged: true
+            runAsUser: 0
+        {{- end }}
+
       terminationGracePeriodSeconds: {{ .Values.container.terminationGracePeriodSeconds }}
       securityContext:
       {{- if .Values.useImagePullSecrets }}
@@ -100,6 +119,11 @@ spec:
         - name: {{ include "memgraph.fullname" . }}-user-storage
           persistentVolumeClaim:
             claimName: {{ include "memgraph.fullname" . }}-user-storage
+      {{- end }}
+      {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
+        - name: {{ include "memgraph.fullname" . }}-core-dumps-storage
+          persistentVolumeClaim:
+            claimName: {{ include "memgraph.fullname" . }}-core-dumps-storage
       {{- end }}
       {{- range .Values.customQueryModules }}
         - name: {{ .volume | quote }}
@@ -164,6 +188,10 @@ spec:
             - name: {{ include "memgraph.fullname" . }}-log-storage
               mountPath: /var/log/memgraph
           {{- end }}
+          {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
+            - name: {{ include "memgraph.fullname" . }}-core-dumps-storage
+              mountPath: {{ .Values.persistentVolumeClaim.coreDumpsMountPath }}
+          {{- end }}
           {{- if .Values.persistentVolumeClaim.createUserClaim }}
             - name: {{ include "memgraph.fullname" . }}-user-storage
               mountPath: {{ .Values.persistentVolumeClaim.userMountPath }}
@@ -210,6 +238,7 @@ spec:
         volumeName: {{ .Values.persistentVolumeClaim.storageVolumeName }}
         {{- end }}
   {{- end }}
+
   {{- if .Values.persistentVolumeClaim.createLogStorage }}
     - metadata:
         name: {{ include "memgraph.fullname" . }}-log-storage
@@ -222,6 +251,20 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistentVolumeClaim.logStorageSize }}
+  {{- end }}
+
+  {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
+    - metadata:
+        name: {{ include "memgraph.fullname" . }}-core-dumps-storage
+      spec:
+        accessModes:
+        - "ReadWriteOnce"
+        {{- if .Values.persistentVolumeClaim.coreDumpsStorageClassName }}
+        storageClassName: {{ .Values.persistentVolumeClaim.coreDumpsStorageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistentVolumeClaim.coreDumpsStorageSize }}
   {{- end }}
 
   {{- if .Values.persistentVolumeClaim.createUserClaim }}

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -58,21 +58,21 @@ spec:
           # k8s environments permissions set under
           # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
           # get overwritten. Sometimes, PVC are created using new partitions ->
-          # .lost+found directory should not / can't change its permissions so
+          # lost+found directory should not / can't change its permissions so
           # it has to be excluded.
           args:
             - >
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-              find /var/lib/memgraph -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
+              chown -R {{ .Values.memgraphUserGroupId }} /var/lib/memgraph || true;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createLogStorage }}
-              find /var/log/memgraph -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
+              chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph || true;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
-              find {{ .Values.persistentVolumeClaim.userMountPath }} -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
+              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }} || true;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-              find {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
+              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
               {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
@@ -80,11 +80,6 @@ spec:
             capabilities:
               drop: ["ALL"]
               add: ["CHOWN"]
-              # TODO(gitbuda): Test on AKS and remove below if above is working.
-              # chown -R {{ .Values.memgraphUserGroupId }} /var/lib/memgraph || true;
-              # chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph || true;
-              # chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }} || true;
-              # chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
 
         {{- if .Values.sysctlInitContainer.enabled }}
         - name: init-sysctl

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -54,19 +54,25 @@ spec:
               mountPath: {{ .Values.persistentVolumeClaim.coreDumpsMountPath }}
           {{- end }}
           command: ["/bin/sh", "-c"]
+          # The permissions have to be explicitly adjusted because under some
+          # k8s environments permissions set under
+          # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
+          # get overwritten. Sometimes, PVC are created using new partitions ->
+          # .lost+found directory should not / can't change its permissions so
+          # it has to be excluded.
           args:
-            - > # Document or change the || true.
+            - > 
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-              chown -R {{ .Values.memgraphUserGroupId }} /var/lib/memgraph || true;
+              find /var/lib/memgraph -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createLogStorage }}
-              chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph || true;
+              find /var/log/memgraph -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
-              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }} || true;
+              find {{ .Values.persistentVolumeClaim.userMountPath }} -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-              chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
+              find {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} -path ./lost+found -prune -o -exec chown -hR {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
@@ -74,6 +80,11 @@ spec:
             capabilities:
               drop: ["ALL"]
               add: ["CHOWN"]
+              # TODO(gitbuda): Test on AKS and remove below if above is working.
+              # chown -R {{ .Values.memgraphUserGroupId }} /var/lib/memgraph || true;
+              # chown -R {{ .Values.memgraphUserGroupId }} /var/log/memgraph || true;
+              # chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.userMountPath }} || true;
+              # chown -R {{ .Values.memgraphUserGroupId }} {{ .Values.persistentVolumeClaim.coreDumpsMountPath }} || true;
 
         {{- if .Values.sysctlInitContainer.enabled }}
         - name: init-sysctl

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -80,7 +80,7 @@ persistentVolumeClaim:
   userMountPath:
 
   ## Create a Persistant Volume Claim for core dumps.
-  createCoreDumpsClaim: true
+  createCoreDumpsClaim: false
   coreDumpsStorageClassName:
   coreDumpsStorageSize: 10Gi
   coreDumpsMountPath: /var/core/memgraph

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -103,6 +103,8 @@ memgraphConfig:
 # Setting the Memgraph's memory limit to more than the available resources can trigger pod eviction and restarts before Memgraph can make a query exception and continue running
 # the pod. For further information, check the `resources` section in this file about setting pod memory and cpu limits.
 - "--also-log-to-stderr=true"
+# TODO(gitbuda): Document -> it depends on our image mage vs memgraph, we should have always the same user and group ids, used for user and core dump claim permissons.
+memgraphUserGroupId: "100:101"
 
 secrets:
   enabled: false

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -79,7 +79,7 @@ persistentVolumeClaim:
   userStorageAccessMode: "ReadWriteOnce"
   userMountPath:
 
-  ## Create a Persistant Volume Claims for Core Dumps
+  ## Create a Persistant Volume Claim for core dumps.
   createCoreDumpsClaim: true
   coreDumpsStorageClassName:
   coreDumpsStorageSize: 10Gi
@@ -103,7 +103,11 @@ memgraphConfig:
 # Setting the Memgraph's memory limit to more than the available resources can trigger pod eviction and restarts before Memgraph can make a query exception and continue running
 # the pod. For further information, check the `resources` section in this file about setting pod memory and cpu limits.
 - "--also-log-to-stderr=true"
-# TODO(gitbuda): Document -> it depends on our image mage vs memgraph, we should have always the same user and group ids, used for user and core dump claim permissons.
+
+# The explicit user and group setup is required because at the init container
+# time, there is not yet a user created. This seems fine because under both
+# Memgraph and Mage images we actually hard-code the user and group id. The
+# config is used to chown user storage and core dumps claims' month paths.
 memgraphUserGroupId: "100:101"
 
 secrets:

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -79,6 +79,12 @@ persistentVolumeClaim:
   userStorageAccessMode: "ReadWriteOnce"
   userMountPath:
 
+  ## Create a Persistant Volume Claims for Core Dumps
+  createCoreDumpsClaim: true
+  coreDumpsStorageClassName:
+  coreDumpsStorageSize: 10Gi
+  coreDumpsMountPath: /var/core/memgraph
+
 # Default Storage Class for data and logs, defaults are for Minikube, make sure to change it for production deployments
 # Examples provisioner: Minikube(k8s.io/minikube-hostpath) AWS (ebs.csi.aws.com), GCP (pd.csi.storage.gke.io), Azure (disk.csi.azure.com)
 # Examples storageType: Minikube(hostPath) AWS (gp2), GCP (pd-standard), Azure (StandardSSD_LRS)

--- a/scripts/aks.bash
+++ b/scripts/aks.bash
@@ -21,14 +21,14 @@ delete_cluster() {
 }
 
 case $1 in
-  create)
+  create_cluster)
     create_cluster
   ;;
-  delete)
+  delete_cluster)
     delete_cluster
   ;;
   *)
-    echo "$0 create|delete"
+    echo "$0 create_cluster|delete_cluster"
     exit 1
   ;;
 esac

--- a/scripts/aks.bash
+++ b/scripts/aks.bash
@@ -8,7 +8,7 @@ NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_A2_v2}"
 
 # NOTE: Assumes installed az and being logged in
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli.
- 
+
 create_cluster() {
   az group create --name $RESOURCE_GROUP --location $LOCATION
   az aks create --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME \

--- a/scripts/init_aks.bash
+++ b/scripts/init_aks.bash
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-TestingResourceGroup}"
+LOCATION="${LOCATION:-northeurope}"
+CLUSTER_NAME="${CLUSTER_NAME:-memgraph-standalone}"
+CLUSTER_SIZE="${CLUSTER_SIZE:-1}"
+NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_A2_v2}"
+
+# NOTE: Assumes installed az and being logged in.
+
+create_cluster() {
+  az group create --name $RESOURCE_GROUP --location $LOCATION
+  az aks create --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME \
+    --node-count $CLUSTER_SIZE --node-vm-size $NODE_VM_SIZE --generate-ssh-keys
+  az aks get-credentials --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME
+}
+
+delete_cluster() {
+  az group delete --name $RESOURCE_GROUP --yes
+}
+
+case $1 in
+  create)
+    create_cluster
+  ;;
+  delete)
+    delete_cluster
+  ;;
+  *)
+    echo "$0 create|delete"
+    exit 1
+  ;;
+esac

--- a/scripts/init_aks.bash
+++ b/scripts/init_aks.bash
@@ -6,8 +6,9 @@ CLUSTER_NAME="${CLUSTER_NAME:-memgraph-standalone}"
 CLUSTER_SIZE="${CLUSTER_SIZE:-1}"
 NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_A2_v2}"
 
-# NOTE: Assumes installed az and being logged in.
-
+# NOTE: Assumes installed az and being logged in
+# https://learn.microsoft.com/en-us/cli/azure/install-azure-cli.
+ 
 create_cluster() {
   az group create --name $RESOURCE_GROUP --location $LOCATION
   az aks create --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME \


### PR DESCRIPTION
 - [x] Figure out the `chown` failures
- [x] Make sure we can get the core dumps at least under Linux host
- [x] Define the right naming, NOW: `/var/core/memgraph`
- [x] Figure out why CI is failing -> seems like this was the problem with setting up the permissions.
    - [x] `tee: /proc/sys/kernel/yama/ptrace_scope: No such file or directory` (this failed locally, but that's not the failure under the CI) -> check if the file is there first
    - [x] Test AKS (Azure) and other apply other code review suggestions
    - [x] Apply `find . -path ./lost+found -prune -o -exec chown -hR username:group {} +` -> doesn't work revert back to `|| true`.
- [x] Add user group under HA.
- [x] Add AKS init script. 
- [x] Seems like the user:group of the lost+found repo got changed... -> debug -> the problem was that find returns `.` and then `chown -R` again finds `lost+found` directory.

### Important Considerations:
* Security: Core dumps can contain sensitive data from your application's memory. Ensure that the storage location for core dumps is properly secured and access is restricted.   
* Resource Usage: Core dumps can be large, especially for memory-intensive applications. Ensure that your storage solution has sufficient capacity and consider limiting the size of core dumps.
* Node Configuration: Modifying the host node's core_pattern often requires privileged access and can affect all processes running on that node, not just your Kubernetes pods. Be cautious when making such changes.
* Container Filesystem Permissions: Ensure that the application within the container has the necessary permissions to write core dump files to the desired location.

### Example
#### For Application-Specific Core Dumps
If your application runs as a specific user and needs to write its own core dumps:
```bash
mkdir -p /var/core/memgraph
chown memgraph:memgraph /var/core/memgraph
```
#### Configuring Core Dump Settings
You'll also want to configure the system's core dump settings:
```bash
ulimit -c unlimited
echo '/var/crash/core.%e.%p.%h.%t' | tee  /proc/sys/kernel/core_pattern
echo "0" | tee /proc/sys/kernel/yama/ptrace_scope
```

### Research Pages
* https://wiki.archlinux.org/title/Core_dump