### PR TITLE
Optionally enable GDB debugging by modifying ptrace_scope

### DIFF
--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -84,6 +84,13 @@ spec:
         {{- end }}
 
       initContainers:
+      {{- if $.Values.debugging.ptrace }}
+      - name: ptrace
+        image: busybox
+        command: ["sh", "-c", "echo 0 > /proc/sys/kernel/yama/ptrace_scope"]
+        securityContext:
+          privileged: true
+      {{- end }}
       - name: init
         image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
         volumeMounts:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -144,6 +144,10 @@ prometheus:
     kubePrometheusStackReleaseName: kube-prometheus-stack
     interval: 15s
 
+# If ptrace is set to true, it will be possible to use gdb inside K8s Pod
+debugging:
+  ptrace: false
+
 # If setting the --memory-limit flag under data instances, check that the amount of resources that a pod has been given is more than the actual memory limit you give to Memgraph
 # Setting the Memgraph's memory limit to more than the available resources can trigger pod eviction and restarts before Memgraph can make a query exception and continue running
 # the pod.

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -34,6 +34,13 @@ spec:
       serviceAccount: {{ .Values.serviceAccount.name | quote }}
       {{- end }}
       initContainers:
+      {{- if .Values.debugging.ptrace }}
+        - name: ptrace
+          image: busybox
+          command: ["sh", "-c", "echo 0 > /proc/sys/kernel/yama/ptrace_scope"]
+          securityContext:
+            privileged: true
+      {{- end }}
         - name: init-volume-mounts
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           volumeMounts:

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -194,3 +194,7 @@ customQueryModules: []
 sysctlInitContainer:
   enabled: true
   maxMapCount: 262144
+
+# If ptrace is set to true, it will be possible to use gdb inside K8s Pod
+debugging:
+  ptrace: false


### PR DESCRIPTION
When using relwithdebinfo containers and debugging.ptrace is set to true, it will be possible to debug Memgraph using gdb inside K8s.