### PR TITLE
Add missing fields to volumeClaimTemplates

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -175,7 +175,9 @@ spec:
         {{- end }}
 
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: memgraph-coordinator-{{ $coordinator.id }}-lib-storage
       spec:
         accessModes:
@@ -185,7 +187,9 @@ spec:
           requests:
             storage: {{ $.Values.storage.coordinators.libPVCSize }}
 
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
       spec:
         accessModes:
@@ -196,7 +200,9 @@ spec:
             storage: {{ $.Values.storage.coordinators.logPVCSize }}
 
     {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: memgraph-coordinator-{{ $coordinator.id }}-core-dumps-storage
       spec:
         accessModes:

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -189,7 +189,9 @@ spec:
         {{- end }}
 
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: memgraph-data-{{ $data.id }}-lib-storage
       spec:
         accessModes:
@@ -198,7 +200,9 @@ spec:
         resources:
           requests:
             storage: {{ $.Values.storage.data.libPVCSize }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: memgraph-data-{{ $data.id }}-log-storage
       spec:
         accessModes:
@@ -209,7 +213,9 @@ spec:
             storage: {{ $.Values.storage.data.logPVCSize }}
 
     {{- if $.Values.storage.data.createCoreDumpsClaim }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: memgraph-data-{{ $data.id }}-core-dumps-storage
       spec:
         accessModes:

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -237,7 +237,9 @@ spec:
       {{- end }}
   volumeClaimTemplates:
   {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ include "memgraph.fullname" . }}-lib-storage
       spec:
         accessModes:
@@ -254,7 +256,9 @@ spec:
   {{- end }}
 
   {{- if .Values.persistentVolumeClaim.createLogStorage }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ include "memgraph.fullname" . }}-log-storage
       spec:
         accessModes:
@@ -268,7 +272,9 @@ spec:
   {{- end }}
 
   {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ include "memgraph.fullname" . }}-core-dumps-storage
       spec:
         accessModes:
@@ -282,7 +288,9 @@ spec:
   {{- end }}
 
   {{- if .Values.persistentVolumeClaim.createUserClaim }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ include "memgraph.fullname" . }}-user-storage
       spec:
         accessModes:


### PR DESCRIPTION
Currently, argocd shows the StatefulSet as out of sync because the cluster adds ApiVersion and Kind to the pvc templates.

<img width="1135" height="470" alt="Screenshot 2025-07-13 at 10 43 30 PM" src="https://github.com/user-attachments/assets/e9a5a148-0119-4314-92af-abeb29f9d02f" />
