### PR TITLE
Fix broken symlinks

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -91,12 +91,12 @@ spec:
         args:
           - >
             cd /var/log/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             cd /var/lib/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
             cd {{ $.Values.storage.coordinators.coreDumpsMountPath }};
-            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             {{- end }}
         securityContext:
           readOnlyRootFilesystem: true

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -91,12 +91,12 @@ spec:
         args:
           - >
             cd /var/log/memgraph;
-            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
             cd /var/lib/memgraph;
-            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
             {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
             cd {{ $.Values.storage.coordinators.coreDumpsMountPath }};
-            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
             {{- end }}
         securityContext:
           readOnlyRootFilesystem: true

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -101,12 +101,12 @@ spec:
         args:
           - >
             cd /var/log/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             cd /var/lib/memgraph;
-            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             {{- if $.Values.storage.data.createCoreDumpsClaim }}
             cd {{ $.Values.storage.data.coreDumpsMountPath }};
-            find . -path ./lost+found -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
             {{- end }}
         securityContext:
           readOnlyRootFilesystem: true

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -101,12 +101,12 @@ spec:
         args:
           - >
             cd /var/log/memgraph;
-            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
             cd /var/lib/memgraph;
-            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
             {{- if $.Values.storage.data.createCoreDumpsClaim }}
             cd {{ $.Values.storage.data.coreDumpsMountPath }};
-            find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ $.Values.memgraphUserGroupId }} {} +;
+            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
             {{- end }}
         securityContext:
           readOnlyRootFilesystem: true

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -64,19 +64,19 @@ spec:
             - >
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}
               cd /var/lib/memgraph;
-              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createLogStorage }}
               cd /var/log/memgraph;
-              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
               cd {{ .Values.persistentVolumeClaim.userMountPath }};
-              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
               cd {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
-              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
           securityContext:
             readOnlyRootFilesystem: true

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -64,19 +64,19 @@ spec:
             - >
               {{- if .Values.persistentVolumeClaim.createStorageClaim }}
               cd /var/lib/memgraph;
-              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createLogStorage }}
               cd /var/log/memgraph;
-              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createUserClaim }}
               cd {{ .Values.persistentVolumeClaim.userMountPath }};
-              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
               {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
               cd {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
-              find . -path ./lost+found -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
+              find . \( -path ./lost+found -o -xtype l \) -prune -o -exec chown {{ .Values.memgraphUserGroupId }} {} +;
               {{- end }}
           securityContext:
             readOnlyRootFilesystem: true

--- a/scripts/aks.bash
+++ b/scripts/aks.bash
@@ -9,10 +9,15 @@ NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_A2_v2}"
 # NOTE: Assumes installed az and being logged in
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli.
 
+# USE:
+# kubectl config get-contexts       # To list all contexts.
+# kubectl config use-context <name> # Change the context.
+
 create_cluster() {
   az group create --name $RESOURCE_GROUP --location $LOCATION
   az aks create --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME \
     --node-count $CLUSTER_SIZE --node-vm-size $NODE_VM_SIZE --generate-ssh-keys
+  # Get remote context from Azure AKS into your local kubectl.
   az aks get-credentials --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME
 }
 

--- a/scripts/aks.bash
+++ b/scripts/aks.bash
@@ -3,6 +3,8 @@
 RESOURCE_GROUP="${RESOURCE_GROUP:-TestingResourceGroup}"
 LOCATION="${LOCATION:-northeurope}"
 CLUSTER_NAME="${CLUSTER_NAME:-memgraph-standalone}"
+# NOTE: If running memgraph HA -> cluster size has to be 5 otherwise cluster
+# won't initialize because of the affinity.
 CLUSTER_SIZE="${CLUSTER_SIZE:-1}"
 NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_A2_v2}"
 


### PR DESCRIPTION
At the time of calling `chown`, some symlinks under `/var/lib/memgraph` might be broken because that was part of the migration procedure when multi-tenancy was added. The symlinks are actually related to the `STORAGE MODE ON_DISK_TRANSACTIONAL;`, when the storage mode on `memgraph` database is changed to `ON_DISK_TRANSACTIONAL` the symlins become valid.

Adding `-h` option to the `chown` to change symlinks themselves instead of the target files/dirs that don't exist.

fixes https://github.com/memgraph/memgraph/issues/3023