### PR TITLE
Start MG charts without root access needed

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -16,6 +16,11 @@ spec:
         app: memgraph-coordinator-{{ $coordinator.id }}
         role: coordinator
     spec:
+      securityContext:
+        runAsUser: {{ $.Values.memgraphUserId }}
+        runAsGroup: {{ $.Values.memgraphGroupId }}
+        fsGroup: {{ $.Values.memgraphGroupId }}
+
       affinity:
         {{- if $.Values.affinity.nodeSelection }}
         # Node Selection Affinity: Scheduled on nodes with specific label key and value
@@ -74,36 +79,6 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
         {{- end }}
       initContainers:
-      - name: init
-        image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
-        volumeMounts:
-        - name: memgraph-coordinator-{{ $coordinator.id }}-lib-storage
-          mountPath: /var/lib/memgraph
-        - name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
-          mountPath: /var/log/memgraph
-        command: [ "/bin/sh","-c" ]
-        # The permissions have to be explicitly adjusted because under some k8s
-        # environments permissions set under
-        # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
-        # get overwritten. Sometimes, PVC are created using new partitions ->
-        # lost+found directory should not change its permissions so it has to
-        # be excluded.
-        args:
-          - >
-            cd /var/log/memgraph;
-            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
-            cd /var/lib/memgraph;
-            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
-            {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
-            cd {{ $.Values.storage.coordinators.coreDumpsMountPath }};
-            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
-            {{- end }}
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: 0 # Run as root
-          capabilities:
-            drop: [ "ALL" ]
-            add: [ "CHOWN" ]
       {{- if $.Values.sysctlInitContainer.enabled }}
       - name: init-sysctl
         image: "{{ $.Values.sysctlInitContainer.image.repository }}:{{ $.Values.sysctlInitContainer.image.tag }}"

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -16,6 +16,10 @@ spec:
         app: memgraph-data-{{ $data.id }}
         role: data
     spec:
+      securityContext:
+        runAsUser: {{ $.Values.memgraphUserId }}
+        runAsGroup: {{ $.Values.memgraphGroupId }}
+        fsGroup: {{ $.Values.memgraphGroupId }}
       affinity:
         {{- if $.Values.affinity.nodeSelection }}
         # Node Selection Affinity: Scheduled on nodes with specific label key and value
@@ -84,36 +88,6 @@ spec:
         {{- end }}
 
       initContainers:
-      - name: init
-        image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
-        volumeMounts:
-        - name: memgraph-data-{{ $data.id }}-lib-storage
-          mountPath: /var/lib/memgraph
-        - name: memgraph-data-{{ $data.id }}-log-storage
-          mountPath: /var/log/memgraph
-        command: [ "/bin/sh","-c" ]
-        # The permissions have to be explicitly adjusted because under some k8s
-        # environments permissions set under
-        # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
-        # get overwritten. Sometimes, PVC are created using new partitions ->
-        # lost+found directory should not change its permissions so it has to
-        # be excluded.
-        args:
-          - >
-            cd /var/log/memgraph;
-            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
-            cd /var/lib/memgraph;
-            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
-            {{- if $.Values.storage.data.createCoreDumpsClaim }}
-            cd {{ $.Values.storage.data.coreDumpsMountPath }};
-            find . -path ./lost+found -prune -o -exec chown -h {{ $.Values.memgraphUserGroupId }} {} +;
-            {{- end }}
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: 0 # Run as root
-          capabilities:
-            drop: [ "ALL" ]
-            add: [ "CHOWN" ]
       {{- if $.Values.sysctlInitContainer.enabled }}
       - name: init-sysctl
         image: "{{ $.Values.sysctlInitContainer.image.repository }}:{{ $.Values.sysctlInitContainer.image.tag }}"

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -170,6 +170,7 @@ data:
   - "--also-log-to-stderr"
   - "--log-level=TRACE"
   - "--log-file=/var/log/memgraph/memgraph.log"
+  - "--data-directory=/var/lib/memgraph/mg_data"
 
 - id: "1"
   args:
@@ -178,6 +179,7 @@ data:
   - "--also-log-to-stderr"
   - "--log-level=TRACE"
   - "--log-file=/var/log/memgraph/memgraph.log"
+  - "--data-directory=/var/lib/memgraph/mg_data"
 
 coordinators:
 - id: "1"
@@ -191,6 +193,7 @@ coordinators:
   - "--coordinator-hostname=memgraph-coordinator-1.default.svc.cluster.local"
   - "--log-file=/var/log/memgraph/memgraph.log"
   - "--nuraft-log-file=/var/log/memgraph/memgraph.log"
+  - "--data-directory=/var/lib/memgraph/mg_data"
 
 - id: "2"
   args:
@@ -203,6 +206,7 @@ coordinators:
   - "--coordinator-hostname=memgraph-coordinator-2.default.svc.cluster.local"
   - "--log-file=/var/log/memgraph/memgraph.log"
   - "--nuraft-log-file=/var/log/memgraph/memgraph.log"
+  - "--data-directory=/var/lib/memgraph/mg_data"
 
 - id: "3"
   args:
@@ -215,3 +219,4 @@ coordinators:
   - "--coordinator-hostname=memgraph-coordinator-3.default.svc.cluster.local"
   - "--log-file=/var/log/memgraph/memgraph.log"
   - "--nuraft-log-file=/var/log/memgraph/memgraph.log"
+  - "--data-directory=/var/lib/memgraph/mg_data"

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -93,7 +93,8 @@ sysctlInitContainer:
 # time, there is not yet a user created. This seems fine because under both
 # Memgraph and Mage images we actually hard-code the user and group id. The
 # config is used to chown user storage and core dumps claims' month paths.
-memgraphUserGroupId: "101:103"
+memgraphUserId: 101
+memgraphGroupId: 103
 
 secrets:
   enabled: false

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -26,65 +26,17 @@ spec:
       annotations:
         {{- toYaml . | nindent 4 }}
       {{- end }}
-
     spec:
+      securityContext:
+        runAsUser: {{ .Values.memgraphUserId }}
+        runAsGroup: {{ .Values.memgraphGroupId }}
+        fsGroup: {{ .Values.memgraphGroupId }}
       {{- if .Values.serviceAccount.create }}
       serviceAccount: {{ include "memgraph.serviceAccountName" . }}
       {{- else if .Values.serviceAccount.name }}
       serviceAccount: {{ .Values.serviceAccount.name | quote }}
       {{- end }}
       initContainers:
-        - name: init-volume-mounts
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          volumeMounts:
-          {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-            - name: {{ include "memgraph.fullname" . }}-lib-storage
-              mountPath: /var/lib/memgraph
-          {{- end }}
-          {{- if .Values.persistentVolumeClaim.createLogStorage }}
-            - name: {{ include "memgraph.fullname" . }}-log-storage
-              mountPath: /var/log/memgraph
-          {{- end }}
-          {{- if .Values.persistentVolumeClaim.createUserClaim }}
-            - name: {{ include "memgraph.fullname" . }}-user-storage
-              mountPath: {{ .Values.persistentVolumeClaim.userMountPath }}
-          {{- end }}
-          {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-            - name: {{ include "memgraph.fullname" . }}-core-dumps-storage
-              mountPath: {{ .Values.persistentVolumeClaim.coreDumpsMountPath }}
-          {{- end }}
-          command: ["/bin/sh", "-c"]
-          # The permissions have to be explicitly adjusted because under some
-          # k8s environments permissions set under
-          # https://github.com/memgraph/memgraph/blob/master/release/debian/postinst
-          # get overwritten. Sometimes, PVC are created using new partitions ->
-          # lost+found directory should not change its permissions so it has to
-          # be excluded.
-          args:
-            - >
-              {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-              cd /var/lib/memgraph;
-              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
-              {{- end }}
-              {{- if .Values.persistentVolumeClaim.createLogStorage }}
-              cd /var/log/memgraph;
-              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
-              {{- end }}
-              {{- if .Values.persistentVolumeClaim.createUserClaim }}
-              cd {{ .Values.persistentVolumeClaim.userMountPath }};
-              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
-              {{- end }}
-              {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-              cd {{ .Values.persistentVolumeClaim.coreDumpsMountPath }};
-              find . -path ./lost+found -prune -o -exec chown -h {{ .Values.memgraphUserGroupId }} {} +;
-              {{- end }}
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 0
-            capabilities:
-              drop: ["ALL"]
-              add: ["CHOWN"]
-
         {{- if .Values.sysctlInitContainer.enabled }}
         - name: init-sysctl
           image: "{{ .Values.sysctlInitContainer.image.repository }}:{{ .Values.sysctlInitContainer.image.tag }}"
@@ -109,42 +61,16 @@ spec:
         {{- end }}
 
       terminationGracePeriodSeconds: {{ .Values.container.terminationGracePeriodSeconds }}
-      securityContext:
       {{- if .Values.useImagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 4 }}
       {{- end }}
       volumes:
-        - name: {{ include "memgraph.fullname" . }}-lib-storage
-          persistentVolumeClaim:
-          {{- if .Values.persistentVolumeClaim.createStorageClaim }}
-            claimName: {{ include "memgraph.fullname" . }}-lib-storage
-          {{- else }}
-            claimName: {{ .Values.persistentVolumeClaim.existingClaim }}
-          {{- end}}
-
-      {{- if .Values.persistentVolumeClaim.createLogStorage }}
-        - name: {{ include "memgraph.fullname" . }}-log-storage
-          persistentVolumeClaim:
-            claimName: {{ include "memgraph.fullname" . }}-log-storage
-      {{- end }}
-
-      {{- if .Values.persistentVolumeClaim.createUserClaim }}
-        - name: {{ include "memgraph.fullname" . }}-user-storage
-          persistentVolumeClaim:
-            claimName: {{ include "memgraph.fullname" . }}-user-storage
-      {{- end }}
-      {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
-        - name: {{ include "memgraph.fullname" . }}-core-dumps-storage
-          persistentVolumeClaim:
-            claimName: {{ include "memgraph.fullname" . }}-core-dumps-storage
-      {{- end }}
       {{- range .Values.customQueryModules }}
         - name: {{ .volume | quote }}
           configMap:
             name: {{ .volume | quote }}
       {{- end }}
-
 
       containers:
         - name: memgraph
@@ -244,9 +170,7 @@ spec:
       spec:
         accessModes:
         - "ReadWriteOnce"
-        {{- if .Values.persistentVolumeClaim.storageClassName }}
         storageClassName: {{ .Values.persistentVolumeClaim.storageClassName }}
-        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistentVolumeClaim.storageSize }}
@@ -263,9 +187,7 @@ spec:
       spec:
         accessModes:
         - "ReadWriteOnce"
-        {{- if .Values.persistentVolumeClaim.logStorageClassName }}
         storageClassName: {{ .Values.persistentVolumeClaim.logStorageClassName }}
-        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistentVolumeClaim.logStorageSize }}
@@ -279,9 +201,7 @@ spec:
       spec:
         accessModes:
         - "ReadWriteOnce"
-        {{- if .Values.persistentVolumeClaim.coreDumpsStorageClassName }}
         storageClassName: {{ .Values.persistentVolumeClaim.coreDumpsStorageClassName }}
-        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistentVolumeClaim.coreDumpsStorageSize }}

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -102,13 +102,15 @@ memgraphConfig:
 # If setting the --memory-limit flag, check that the amount of resources that a pod has been given is more than the actual memory limit you give to Memgraph
 # Setting the Memgraph's memory limit to more than the available resources can trigger pod eviction and restarts before Memgraph can make a query exception and continue running
 # the pod. For further information, check the `resources` section in this file about setting pod memory and cpu limits.
+- "--data-directory=/var/lib/memgraph/mg_data"
 - "--also-log-to-stderr=true"
 
 # The explicit user and group setup is required because at the init container
 # time, there is not yet a user created. This seems fine because under both
 # Memgraph and Mage images we actually hard-code the user and group id. The
 # config is used to chown user storage and core dumps claims' month paths.
-memgraphUserGroupId: "101:103"
+memgraphUserId: 101
+memgraphGroupId: 103
 
 secrets:
   enabled: false


### PR DESCRIPTION
If you have problems with your deployment on minikube:
1. enable CSI
```
minikube addons disable storage-provisioner
minikube addons disable default-storageclass
minikube addons enable volumesnapshots
minikube addons enable csi-hostpath-driver
```
2. create a storage class with sc.yaml file
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: csi-hostpath-delayed
provisioner: hostpath.csi.k8s.io
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
```
3. `kubectl apply -f sc.yaml`
4. For HA, update `libStorageClassName` to `csi-hostpath-delayed`. For standalone, update `storageClassName` to the `csi-hostpaht-delayed`.



NOTE: Privileged access is needed for sysctl to update vm max map count.
Context from K8s minikube community: https://github.com/kubernetes/minikube/issues/12360

NOTE: Works on all 3 big cloud platforms
