### PR TITLE
feat: Add optional custom initContainers

### DIFF
--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -60,6 +60,10 @@ spec:
             runAsUser: 0
         {{- end }}
 
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
       terminationGracePeriodSeconds: {{ .Values.container.terminationGracePeriodSeconds }}
       {{- if .Values.useImagePullSecrets }}
       imagePullSecrets:

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -200,3 +200,14 @@ sysctlInitContainer:
     repository: library/busybox
     tag: latest
     pullPolicy: IfNotPresent
+
+## @param initContainers Add additional init containers to the Memgraph pod(s)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## e.g:
+## initContainers:
+##  - name: your-image-name
+##    image: your-image
+##    imagePullPolicy: Always
+##    command: ['sh', '-c', 'echo "hello world"']
+##
+initContainers: []


### PR DESCRIPTION
Allow optional `initContainers`. 

For my particular use-case I need to increase the stack size. 