### PR TITLE
feat: Support defining custom command for container probes

### DIFF
--- a/charts/memgraph/templates/_helpers.tpl
+++ b/charts/memgraph/templates/_helpers.tpl
@@ -63,29 +63,56 @@ Create the name of the service account to use
 
 {{- define "container.readinessProbe" -}}
 readinessProbe:
+{{- if .exec }}
+  exec:
+    command:
+{{- range .exec.command }}
+    - {{ . | quote }}
+{{- end }}
+{{- else }}
   tcpSocket:
     port: {{ .tcpSocket.port }}
+{{- end }}
   failureThreshold: {{ .failureThreshold }}
   timeoutSeconds: {{ .timeoutSeconds }}
   periodSeconds: {{ .periodSeconds }}
+  initialDelaySeconds: {{ .initialDelaySeconds }}
 {{- end }}
 
 
 {{- define "container.livenessProbe" -}}
 livenessProbe:
+{{- if .exec }}
+  exec:
+    command:
+{{- range .exec.command }}
+    - {{ . | quote }}
+{{- end }}
+{{- else }}
   tcpSocket:
     port: {{ .tcpSocket.port }}
+{{- end }}
   failureThreshold: {{ .failureThreshold }}
   timeoutSeconds: {{ .timeoutSeconds }}
   periodSeconds: {{ .periodSeconds }}
+  initialDelaySeconds: {{ .initialDelaySeconds }}
 {{- end }}
 
 
 {{- define "container.startupProbe" -}}
 startupProbe:
+{{- if .exec }}
+  exec:
+    command:
+{{- range .exec.command }}
+    - {{ . | quote }}
+{{- end }}
+{{- else }}
   tcpSocket:
     port: {{ .tcpSocket.port }}
+{{- end }}
   failureThreshold: {{ .failureThreshold }}
   timeoutSeconds: {{ .timeoutSeconds }}
   periodSeconds: {{ .periodSeconds }}
+  initialDelaySeconds: {{ .initialDelaySeconds }}
 {{- end }}

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -154,11 +154,15 @@ container:
   terminationGracePeriodSeconds: 1800
   # When a container is ready to be used. Disabled until startupProbe succeeds.
   readinessProbe:
+    # Defining exec.command overrides tcpSocket.
+    # exec:
+    #   command: ["/bin/sh", "-c", "echo 'RETURN 0;' | mgconsole"]
     tcpSocket:
       port: 7687
     failureThreshold: 20
     timeoutSeconds: 10
     periodSeconds: 5
+    initialDelaySeconds: 0
   # To know when a container needs to be restarted.
   # Disabled until startupProbe succeeds.
   livenessProbe:
@@ -167,12 +171,15 @@ container:
     failureThreshold: 20
     timeoutSeconds: 10
     periodSeconds: 5
+    initialDelaySeconds: 0
   # When restoring Memgraph from a backup, it is important to give enough time app to start. Here, we set it to 2h by default.
   startupProbe:
     tcpSocket:
       port: 7687
     failureThreshold: 1440
+    timeoutSeconds: 1
     periodSeconds: 5
+    initialDelaySeconds: 0
 
 # List of custom query modules to be mounted into the app.
 # These will be loaded automatically, on startup.


### PR DESCRIPTION
Issue: It is possible for memgraph to get unresponsive to cypher queries, which cannot be detected by tcp probes.

The pull request adds possibility to support custom command for probes, with values.yaml providing an example for running cypher queries with mgconsole.

Some probe options are also added with same default value as [kuberentes doc](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) for convenience.
