### PR TITLE
Fix .Values.service.enableBolt not being used

### DIFF
--- a/charts/memgraph/templates/service.yaml
+++ b/charts/memgraph/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    {{- if .Values.service.boltPort }}
+    {{- if .Values.service.enableBolt }}
     - port: {{ .Values.service.boltPort }}
       targetPort: {{ .Values.service.boltPort }}
       protocol: TCP


### PR DESCRIPTION
There is a mis-use of values in `templates/service.yaml` which resulted in `.Values.service.enableBolt` not actually being used.


```yaml
service:
  ...
  # Bolt Port
  enableBolt: true
  boltPort: 7687  # NOTE: Make sure to change port in probes if you change this value.

  # Websocket Monitoring
  enableWebsocketMonitoring: false
  websocketPortMonitoring: 7444

  # HTTP Monitoring
  enableHttpMonitoring: false
  httpPortMonitoring: 9091
  annotations: {}
  labels: {}
```

With the fix, mentioned value can actually disable bolt port:

```bash
# After the fix, value can actually remove boltPort from service
$ helm template charts/memgraph/ --set service.enableBolt=false --show-only templates/service.yaml
---
# Source: memgraph/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-memgraph
spec:
  type: ClusterIP
  ports:
  selector:
    app.kubernetes.io/name: memgraph
    app.kubernetes.io/instance: release-name
```


The fix has no impact to rendered manifest:


```bash
$ git log
commit 166ca30cc8b04c7cc59c57c3ec7d2a0784d20ac3 (HEAD -> bug-fix, origin/bug-fix)
Author: Rophy Tsai <rophy@users.noreply.github.com>
Date:   Thu Sep 18 16:49:31 2025 +0800

    Fix .Values.service.enableBolt not being used

commit 219c0a15baba45243905b9eb3acb3bca65af4fc6 (upstream/main)
Author: Andi Skrgat <andi8647@gmail.com>
Date:   Wed Sep 17 15:04:55 2025 +0200

    feat: Add support for defining custom env variables (#170)

commit 2b281fd13d1732d835c5f924c28336f2c88eea7c (tag: memgraph-high-availability-0.2.6, tag: memgraph-0.2.7)
Author: Dr Matt James <mattkjames7@gmail.com>
Date:   Fri Sep 12 12:12:30 2025 +0100

    Bump Memgraph version to 3.5.1 (#168)
...


$ git checkout upstream/main && helm template charts/memgraph/ --output-dir=before-patch
HEAD is now at 219c0a1 feat: Add support for defining custom env variables (#170)
wrote before-patch/memgraph/templates/serviceaccount.yaml
wrote before-patch/memgraph/templates/service.yaml
wrote before-patch/memgraph/templates/statefulset.yaml
wrote before-patch/memgraph/templates/tests/test-connection.yaml

$ git checkout origin/bug-fix && helm template charts/memgraph/ --output-dir=after-patch
HEAD is now at 166ca30 Fix .Values.service.enableBolt not being used
wrote after-patch/memgraph/templates/serviceaccount.yaml
wrote after-patch/memgraph/templates/service.yaml
wrote after-patch/memgraph/templates/statefulset.yaml
wrote after-patch/memgraph/templates/tests/test-connection.yaml

$ diff -urN before-patch/ after-patch/
# no difference

```



```