### PR TITLE
feat: Add tolerations to HA chart

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -32,7 +32,10 @@ spec:
         runAsUser: {{ $.Values.memgraphUserId }}
         runAsGroup: {{ $.Values.memgraphGroupId }}
         fsGroup: {{ $.Values.memgraphGroupId }}
-
+      {{- with $.Values.tolerations.coordinators }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         {{- if $.Values.affinity.nodeSelection }}
         # Node Selection Affinity: Scheduled on nodes with specific label key and value

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -31,6 +31,10 @@ spec:
         runAsUser: {{ $.Values.memgraphUserId }}
         runAsGroup: {{ $.Values.memgraphGroupId }}
         fsGroup: {{ $.Values.memgraphGroupId }}
+      {{- with $.Values.tolerations.data }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         {{- if $.Values.affinity.nodeSelection }}
         # Node Selection Affinity: Scheduled on nodes with specific label key and value

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -283,3 +283,19 @@ userContainers:
   #  - name: my-debugger
   #    image: busybox
   #    command: ["sh", "-c", "echo hi; sleep 10000"]
+
+tolerations:
+  data: []
+  # Example:
+  # data:
+  #   - key: "key2"
+  #     operator: "Equal"
+  #     value: "value2"
+  #     effect: "NoSchedule"
+  coordinators: []
+  # Example:
+  # coordinators:
+  #   - key: "key1"
+  #     operator: "Equal"
+  #     value: "value1"
+  #     effect: "NoSchedule"


### PR DESCRIPTION
HA chart now supports setting `tolerations` to coordinator and data instance pods.