### PR TITLE
feat: Make stricter SecurityContext

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -33,6 +33,9 @@ spec:
         runAsUser: {{ $.Values.memgraphUserId }}
         runAsGroup: {{ $.Values.memgraphGroupId }}
         fsGroup: {{ $.Values.memgraphGroupId }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       {{- with $.Values.tolerations.coordinators }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -103,6 +106,7 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
+          runAsNonRoot: false
       {{- end }}
 
       {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
@@ -116,6 +120,7 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
+          runAsNonRoot: false
       {{- end }}
 
       {{- with $.Values.initContainers.coordinators }}
@@ -167,6 +172,10 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: [ "ALL" ]
+          readOnlyRootFilesystem: false # Some python libs like scipy are writing to tmp folder
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
           # Run by 'memgraph' user as specified in the Dockerfile
         {{- include "container.coordinators.readinessProbe" $.Values.container.coordinators.readinessProbe | nindent 8 }}
         {{- include "container.coordinators.livenessProbe" $.Values.container.coordinators.livenessProbe | nindent 8 }}

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -32,6 +32,9 @@ spec:
         runAsUser: {{ $.Values.memgraphUserId }}
         runAsGroup: {{ $.Values.memgraphGroupId }}
         fsGroup: {{ $.Values.memgraphGroupId }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       {{- with $.Values.tolerations.data }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -112,6 +115,7 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
+          runAsNonRoot: false
       {{- end }}
 
       {{- if $.Values.storage.data.createCoreDumpsClaim }}
@@ -125,6 +129,7 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
+          runAsNonRoot: false
       {{- end }}
 
       {{- with $.Values.initContainers.data }}
@@ -176,6 +181,10 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: [ "ALL" ]
+          readOnlyRootFilesystem: false # Some python libs like scipy are writing to tmp folder
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
           # Run by 'memgraph' user as specified in the Dockerfile
         {{- include "container.data.readinessProbe" $.Values.container.data.readinessProbe | nindent 8 }}
         {{- include "container.data.livenessProbe" $.Values.container.data.livenessProbe | nindent 8 }}

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -31,6 +31,9 @@ spec:
         runAsUser: {{ .Values.memgraphUserId }}
         runAsGroup: {{ .Values.memgraphGroupId }}
         fsGroup: {{ .Values.memgraphGroupId }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.serviceAccount.create }}
       serviceAccount: {{ include "memgraph.serviceAccountName" . }}
       {{- else if .Values.serviceAccount.name }}
@@ -45,6 +48,7 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+            runAsNonRoot: false
         {{- end }}
 
         {{- if .Values.persistentVolumeClaim.createCoreDumpsClaim }}
@@ -58,6 +62,7 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+            runAsNonRoot: false
         {{- end }}
 
         {{- with .Values.initContainers }}
@@ -101,6 +106,10 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+            readOnlyRootFilesystem: false # Some python libs like scipy are writing to tmp folder
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           # Run by 'memgraph' user as specified in the Dockerfile
           {{- include "container.readinessProbe" .Values.container.readinessProbe | nindent 10 }}
           {{- include "container.livenessProbe" .Values.container.livenessProbe | nindent 10 }}


### PR DESCRIPTION
Use RuntimeDefault as seccomp profile and specify runAsNonRoot to true.