### PR TITLE
fix: Cluster setup with SSL

### DIFF
--- a/charts/memgraph-high-availability/templates/cluster-setup.yaml
+++ b/charts/memgraph-high-availability/templates/cluster-setup.yaml
@@ -1,3 +1,11 @@
+{{- $hasCert := false }}
+  {{- $hasKey := false }}
+  {{- range (index .Values.coordinators 0).args }}
+    {{- if hasPrefix "--bolt-cert-file" . }}{{- $hasCert = true }}{{- end }}
+    {{- if hasPrefix "--bolt-key-file" . }}{{- $hasKey = true }}{{- end }}
+  {{- end }}
+  {{- $useSSL := and $hasCert $hasKey | ternary "--use-ssl" "" }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -52,7 +60,7 @@ spec:
               {{- end }}
 
               # Check if instances are already registered
-              INSTANCE_COUNT=$(echo "SHOW INSTANCES;" | mgconsole --host memgraph-coordinator-{{ (index .Values.coordinators 0).id }}.{{ .Release.Namespace }}.svc.cluster.local --port {{$.Values.ports.boltPort }} --output-format=csv 2>/dev/null | tail -n +2 | wc -l)
+              INSTANCE_COUNT=$(echo "SHOW INSTANCES;" | mgconsole {{ $useSSL }} --host memgraph-coordinator-{{ (index .Values.coordinators 0).id }}.{{ .Release.Namespace }}.svc.cluster.local --port {{$.Values.ports.boltPort }} --output-format=csv 2>/dev/null | tail -n +2 | wc -l)
               if [ "$INSTANCE_COUNT" -gt 1 ]; then
                 echo "✅ Cluster already configured with $INSTANCE_COUNT instances. Skipping registration."
                 exit 0
@@ -60,13 +68,13 @@ spec:
 
               # Add all coordinators
               {{- range .Values.coordinators }}
-              echo 'ADD COORDINATOR {{ .id }} WITH CONFIG {"bolt_server": "memgraph-coordinator-{{ .id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.boltPort }}", "management_server": "memgraph-coordinator-{{ .id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.managementPort }}", "coordinator_server": "memgraph-coordinator-{{ .id }}.{{$.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.coordinatorPort }}"};' | mgconsole --host memgraph-coordinator-{{ (index $.Values.coordinators 0).id }}.{{ $.Release.Namespace}}.svc.cluster.local --port {{ $.Values.ports.boltPort }}
+              echo 'ADD COORDINATOR {{ .id }} WITH CONFIG {"bolt_server": "memgraph-coordinator-{{ .id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.boltPort }}", "management_server": "memgraph-coordinator-{{ .id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.managementPort }}", "coordinator_server": "memgraph-coordinator-{{ .id }}.{{$.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.coordinatorPort }}"};' | mgconsole {{ $useSSL }} --host memgraph-coordinator-{{ (index $.Values.coordinators 0).id }}.{{ $.Release.Namespace}}.svc.cluster.local --port {{ $.Values.ports.boltPort }}
               {{- end }}
 
               # Register all data instances
               {{- range $index, $instance := .Values.data }}
-              echo 'REGISTER INSTANCE instance_{{ add $index 1 }} WITH CONFIG {"bolt_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{$.Values.ports.boltPort }}", "management_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.managementPort }}", "replication_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.replicationPort }}"};' | mgconsole --host memgraph-coordinator-{{ (index $.Values.coordinators 0).id }}.{{ $.Release.Namespace }}.svc.cluster.local --port {{ $.Values.ports.boltPort }}
+              echo 'REGISTER INSTANCE instance_{{ add $index 1 }} WITH CONFIG {"bolt_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{$.Values.ports.boltPort }}", "management_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.managementPort }}", "replication_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.ports.replicationPort }}"};' | mgconsole {{ $useSSL }} --host memgraph-coordinator-{{ (index $.Values.coordinators 0).id }}.{{ $.Release.Namespace }}.svc.cluster.local --port {{ $.Values.ports.boltPort }}
               {{- end }}
 
               # Set first data instance as MAIN
-              echo 'SET INSTANCE instance_1 TO MAIN;' | mgconsole --host memgraph-coordinator-{{ (index .Values.coordinators 0).id }}.{{ $.Release.Namespace }}.svc.cluster.local --port {{ $.Values.ports.boltPort }}
+              echo 'SET INSTANCE instance_1 TO MAIN;' | mgconsole {{ $useSSL }} --host memgraph-coordinator-{{ (index .Values.coordinators 0).id }}.{{ $.Release.Namespace }}.svc.cluster.local --port {{ $.Values.ports.boltPort }}


### PR DESCRIPTION
Cluster setup wouldn't work if Memgraph would have been started with TLS options enabled (--bolt-key-file and --bolt-cert-file).

No need for docs because cluster setup functionality isn't released yet.