### PR TITLE
feat: Add metrics port definition

### DIFF
--- a/charts/memgraph-high-availability/templates/services-coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/services-coordinators.yaml
@@ -30,8 +30,8 @@ spec:
     {{- if $.Values.prometheus.enabled }}
     - protocol: TCP
       name: tcp-metrics-port
-      port: 9091
-      targetPort: 9091
+      port: {{ $.Values.ports.metricsPort }}
+      targetPort: {{ $.Values.ports.metricsPort }}
     {{- end }}
 
 {{- end }}

--- a/charts/memgraph-high-availability/templates/services-data.yaml
+++ b/charts/memgraph-high-availability/templates/services-data.yaml
@@ -30,7 +30,7 @@ spec:
     {{- if $.Values.prometheus.enabled }}
     - protocol: TCP
       name: tcp-metrics-port
-      port: 9091
-      targetPort: 9091
+      port: {{ $.Values.ports.metricsPort }}
+      targetPort: {{ $.Values.ports.metricsPort }}
     {{- end }}
 {{- end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -44,6 +44,7 @@ ports:
   managementPort: 10000
   replicationPort: 20000
   coordinatorPort: 12000 # If you change this value, change it also in probes definition
+  metricsPort: 9091
 
 externalAccessConfig:
   dataInstance:


### PR DESCRIPTION
Metrics port added to values.yaml definition. Opened only if Prometheus monitoring is enabled.