### PR TITLE
feat: Add a script for debugging Memgraph using ephemeral containers

### DIFF
--- a/charts/memgraph-high-availability/templates/NOTES.txt
+++ b/charts/memgraph-high-availability/templates/NOTES.txt
@@ -1,22 +1,3 @@
 Thank you for installing the Memgraph High-availability cluster (Enterprise)! 🎉
 
 You can find information about installing this chart on Memgraph docs https://memgraph.com/docs/getting-started/install-memgraph/kubernetes.
-
-## Debugging with GDB
-
-To attach GDB to a running Memgraph instance without restarting the pod:
-
-  ./scripts/debug-memgraph.sh <pod-name> [-n <namespace>]
-
-Example:
-  ./scripts/debug-memgraph.sh memgraph-data-0-0
-  ./scripts/debug-memgraph.sh memgraph-coordinator-1-0 -n my-namespace
-
-Or manually (create a custom profile to override the pod's non-root securityContext):
-  echo '{"securityContext":{"runAsUser":0,"runAsGroup":0,"runAsNonRoot":false}}' > /tmp/debug-profile.json
-  kubectl debug -it <pod> --image=ubuntu:22.04 --target=memgraph-data \
-    --profile=sysadmin --custom=/tmp/debug-profile.json -- bash
-  # Inside: apt-get update && apt-get install -y gdb procps
-  # Then:   gdb -p $(pgrep -x memgraph) -ex continue
-
-Requires: kubectl 1.32+, Kubernetes 1.25+, cluster must allow privileged ephemeral containers.


### PR DESCRIPTION
## What

Add a convenience script `scripts/debug-memgraph.sh` that attaches a GDB debug container to a running Memgraph HA pod using `kubectl debug` ephemeral containers. The script
auto-detects the target container name (`memgraph-data` or `memgraph-coordinator`) from the pod name, creates a temporary custom profile to override the pod's non-root
`securityContext`, and attaches GDB with `-ex continue` so the process keeps running until a crash signal is caught. Also adds GDB debugging instructions to
`charts/memgraph-high-availability/templates/NOTES.txt`.

## Why

When debugging Memgraph crashes caused by specific queries in HA deployments, developers need to attach GDB to the running process. Restarting pods is undesirable because
Memgraph recovery can be slow for large datasets. This script wraps the `kubectl debug` workflow and handles the non-trivial security context override needed because Memgraph
pods run as non-root (uid 101) with `runAsNonRoot: true`.

## How

- The HA chart's pod-level `securityContext` (`runAsUser: 101`, `runAsNonRoot: true`) prevents ephemeral containers from running as root, which blocks both `apt-get install` and
`ptrace`. The script generates a temporary `--custom` profile JSON that sets `runAsUser: 0` on the ephemeral container only, used together with `--profile=sysadmin` for full
`SYS_PTRACE` capability.
- GDB attaches with `-ex continue` so the Memgraph process is not paused — it keeps running and GDB only breaks on crash signals (SIGSEGV, SIGABRT, etc.).
- No chart template changes are needed for the core functionality — `kubectl debug --target` handles PID namespace sharing without requiring `shareProcessNamespace` on the pod
spec.

**Files changed:**
- `scripts/debug-memgraph.sh` — New convenience wrapper script

## Testing

- Deployed HA chart on AKS cluster and verified the script attaches successfully
- Confirmed ephemeral container runs as root and can install packages / use ptrace
- Verified `pgrep -x memgraph` finds the process PID through shared PID namespace
- Verified GDB attaches and catches SIGSEGV sent via `kubectl exec <pod> -c memgraph-data -- kill -SIGSEGV <PID>`
- Verified the Memgraph pod is never restarted during the debug session
- No new helm tests added — this is a standalone script that doesn't affect chart rendering or deployment

## Notes for reviewers

- Requires `kubectl` 1.32+ (the `--custom` flag for `kubectl debug` went GA in 1.32). Older kubectl versions will fail with an unknown flag error.
- The `apt-get install gdb` step inside the ephemeral container adds ~30s latency before GDB attaches. A follow-up could add a pre-built debug image with GDB already installed,
or a gdbserver sidecar approach for instant attach.
- The script cleans up the temporary custom profile JSON via `trap ... EXIT`.