### PR TITLE
feat: Add env var KEEP_ALIVE_TIMEOUT_MS to Lab

### DIFF
--- a/charts/memgraph-lab/README.md
+++ b/charts/memgraph-lab/README.md
@@ -52,5 +52,7 @@ env:
     value: "7687"
   - name: BASE_PATH
     value: /
+  - name: KEEP_ALIVE_TIMEOUT_MS
+    value: "0"
 ```
 Refer to the [Memgraph Lab documentation](https://memgraph.com/docs/data-visualization) for details on how to connect to and interact with Memgraph.

--- a/charts/memgraph-lab/values.yaml
+++ b/charts/memgraph-lab/values.yaml
@@ -51,6 +51,8 @@ env:
   value: "7687"
 - name: BASE_PATH
   value: ""
+- name: KEEP_ALIVE_TIMEOUT_MS
+  value: "0"
 
 podSecurityContext: {}
 


### PR DESCRIPTION
Default to not using KEEP_ALIVE_TIMEOUT_MS. Users can set this to value different from 0 in order to have better memory management. 