### PR TITLE
fix: Helm handling of large vm max map count

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -102,7 +102,7 @@ spec:
       - name: init-sysctl
         image: "{{ $.Values.sysctlInitContainer.image.repository }}:{{ $.Values.sysctlInitContainer.image.tag }}"
         imagePullPolicy: {{ $.Values.sysctlInitContainer.image.pullPolicy }}
-        command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
+        command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ int64 $.Values.sysctlInitContainer.maxMapCount }}']
         securityContext:
           privileged: true
           runAsUser: 0

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -111,7 +111,7 @@ spec:
       - name: init-sysctl
         image: "{{ $.Values.sysctlInitContainer.image.repository }}:{{ $.Values.sysctlInitContainer.image.tag }}"
         imagePullPolicy: {{ $.Values.sysctlInitContainer.image.pullPolicy }}
-        command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ $.Values.sysctlInitContainer.maxMapCount }}']
+        command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ int64 $.Values.sysctlInitContainer.maxMapCount }}']
         securityContext:
           privileged: true
           runAsUser: 0

--- a/charts/memgraph-lab/values.yaml
+++ b/charts/memgraph-lab/values.yaml
@@ -80,9 +80,9 @@ ingress:
 
 gateway:
   enabled: false
-  gatewayClassName: "" # Required when creating a new Gateway. Name of a pre-existing GatewayClass (e.g., "eg" for Envoy Gateway)
-  existingGatewayName: "" # If set, skip Gateway creation and attach routes to this existing Gateway
-  existingGatewayNamespace: "" # Namespace of the existing Gateway. Defaults to release namespace if empty
+  gatewayClassName: ""  # Required when creating a new Gateway. Name of a pre-existing GatewayClass (e.g., "eg" for Envoy Gateway)
+  existingGatewayName: ""  # If set, skip Gateway creation and attach routes to this existing Gateway
+  existingGatewayNamespace: ""  # Namespace of the existing Gateway. Defaults to release namespace if empty
   annotations: {}
   labels: {}
   listeners:
@@ -96,7 +96,7 @@ gateway:
     #     certificateRefs:
     #       - name: lab-tls-secret
   httpRoute:
-    sectionNames: [] # Listener names to attach to on the Gateway. If empty, derived from listeners[].name
+    sectionNames: []  # Listener names to attach to on the Gateway. If empty, derived from listeners[].name
     # - lab-http
     hostnames: []
     # - lab.example.com

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         - name: init-sysctl
           image: "{{ .Values.sysctlInitContainer.image.repository }}:{{ .Values.sysctlInitContainer.image.tag }}"
           imagePullPolicy: {{ .Values.sysctlInitContainer.image.pullPolicy }}
-          command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ .Values.sysctlInitContainer.maxMapCount }}']
+          command: ['sh', '-c', 'sysctl -w vm.max_map_count={{ int64 .Values.sysctlInitContainer.maxMapCount }}']
           securityContext:
             privileged: true
             runAsUser: 0


### PR DESCRIPTION
Helm could use scientific notation for large numbers which could be unparsable for sysctl. Now we force it to use plain integer string notation.