### PR TITLE
Allow defaulting to release namespace for ServiceMonitor

### DIFF
--- a/charts/memgraph-high-availability/templates/mg-exporter.yaml
+++ b/charts/memgraph-high-availability/templates/mg-exporter.yaml
@@ -80,7 +80,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: mg-exporter
-  namespace: {{ $.Values.prometheus.namespace }}
+  namespace: {{ $.Values.prometheus.namespace | default $.Release.Namespace }}
   labels:
     release: {{ $.Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
 spec:
@@ -92,6 +92,6 @@ spec:
       interval: {{ $.Values.prometheus.serviceMonitor.interval }}
   namespaceSelector:
     matchNames:
-      - {{ $.Values.prometheus.namespace }} # This refers to where our service exposing the exporter is located
+      - {{ $.Values.prometheus.namespace | default $.Release.Namespace }} # This refers to where our service exposing the exporter is located
 {{- end }}
 {{- end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -209,7 +209,7 @@ updateStrategy:
 
 prometheus:
   enabled: false
-  namespace: monitoring # Namespace where K8s resources from mg-exporter.yaml will be installed and where your kube-prometheus-stack chart is installed
+  namespace: monitoring # Namespace where K8s resources from mg-exporter.yaml will be installed and where your kube-prometheus-stack chart is installed, can be left empty to use release namespace.
   memgraphExporter:
     port: 9115
     pullFrequencySeconds: 5

--- a/charts/memgraph/templates/mg-exporter.yaml
+++ b/charts/memgraph/templates/mg-exporter.yaml
@@ -71,7 +71,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: mg-exporter
-  namespace: {{ .Values.prometheus.namespace }}
+  namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
     release: {{ .Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
 spec:
@@ -83,6 +83,6 @@ spec:
       interval: {{ .Values.prometheus.serviceMonitor.interval }}
   namespaceSelector:
     matchNames:
-      - {{ .Values.prometheus.namespace }} # This refers to where our service exposing the exporter is located
+      - {{ .Values.prometheus.namespace | default .Release.Namespace }} # This refers to where our service exposing the exporter is located
 {{- end }}
 {{- end }}

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -303,7 +303,7 @@ initContainers: []
 
 prometheus:
   enabled: false
-  namespace: monitoring  # Namespace where K8s resources from mg-exporter.yaml will be installed and where your kube-prometheus-stack chart is installed
+  namespace: monitoring  # Namespace where K8s resources from mg-exporter.yaml will be installed and where your kube-prometheus-stack chart is installed, can be left empty to use release namespace.
   memgraphExporter:
     port: 9115
     pullFrequencySeconds: 5


### PR DESCRIPTION
This would allow to specify an empty prometheus.namespace falling back to release namespace.
In our case, we generate many instances of memgraph, deployed via Argocd, to sepecific namespaces, and this would avoid having to inject the calculated namespace value in values.
