### PR TITLE
Allow templating on .Values.env

### DIFF
--- a/charts/memgraph-lab/templates/_helpers.tpl
+++ b/charts/memgraph-lab/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Get the base path env value
 {{- define "getBasePath" -}}
 {{- range .Values.env }}
   {{- if eq .name "BASE_PATH" }}
-    {{- .value }}
+    {{- tpl (.value | toString) $ }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/memgraph-lab/templates/deployment.yaml
+++ b/charts/memgraph-lab/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- range .Values.env }}
             - name: {{ .name }}
-              value: "{{ .value }}"
+              value: {{ tpl (.value | toString) $ | quote }}
             {{- end }}
 
 

--- a/charts/memgraph-lab/values.yaml
+++ b/charts/memgraph-lab/values.yaml
@@ -44,6 +44,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Supported env variables: https://memgraph.com/docs/data-visualization/install-and-connect#environment-variables
+# value fields support Helm template expressions, e.g. value: '{{ include "memgraph-lab.fullname" . }}'
 env:
 - name: QUICK_CONNECT_MG_HOST
   value: memgraph-db


### PR DESCRIPTION
Allow using templating in env field in Values.
This enables dynamically configuring SSO for example.
Such as:
```
memgraph-lab:
  env:
    - name: QUICK_CONNECT_MG_HOST
      value: '{{ include "memgraph.dbServiceName" . }}'
    - name: QUICK_CONNECT_MG_PORT
      value: "7687"
    # SSO: Entra ID callback URL (tpl-evaluated by memgraph-lab sub-chart)
    - name: AUTH_OIDC_ENTRA_ID_CALLBACK_URL
      value: 'https://{{ include "memgraph.dbServiceName" . }}.{{ .Release.Namespace }}.{{ .Values.global.hostPostfix }}/auth/providers/oidc-entra-id/callback'
    - name: AUTH_OIDC_ENTRA_ID_IS_ENABLED
      value: "true"
```
