### PR TITLE
Allow templating of extraVolumes

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -204,7 +204,7 @@ spec:
 
       {{- if $.Values.storage.coordinators.extraVolumes }}
       volumes:
-      {{- toYaml $.Values.storage.coordinators.extraVolumes | nindent 6 }}
+      {{- tpl (toYaml $.Values.storage.coordinators.extraVolumes) $ | nindent 6 }}
       {{- end }}
 
   volumeClaimTemplates:

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -212,7 +212,7 @@ spec:
 
       {{- if $.Values.storage.data.extraVolumes }}
       volumes:
-      {{- toYaml $.Values.storage.data.extraVolumes | nindent 6 }}
+      {{- tpl (toYaml $.Values.storage.data.extraVolumes) $ | nindent 6 }}
       {{- end }}
 
   volumeClaimTemplates:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -24,6 +24,7 @@ storage:
     coreDumpsStorageClassName:
     coreDumpsStorageSize: 10Gi
     coreDumpsMountPath: /var/core/memgraph
+    # Supports Helm templating (e.g. {{ .Release.Name }})
     extraVolumes: []
     # extraVolumes:
     #   - name: bolt-certs
@@ -55,6 +56,7 @@ storage:
     coreDumpsStorageClassName:
     coreDumpsStorageSize: 10Gi
     coreDumpsMountPath: /var/core/memgraph
+    # Supports Helm templating (e.g. {{ .Release.Name }})
     extraVolumes: []
     # Example:
     # extraVolumes:

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -81,7 +81,7 @@ spec:
             name: {{ .volume | quote }}
       {{- end }}
       {{- if .Values.extraVolumes }}
-      {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- tpl (toYaml .Values.extraVolumes) . | nindent 8 }}
       {{- end }}
 
       containers:

--- a/charts/memgraph/values.yaml
+++ b/charts/memgraph/values.yaml
@@ -261,7 +261,7 @@ customQueryModules: []
 ##       command: ["/scripts/pre-stop.sh"]
 lifecycleHooks: {}
 
-## @param extraVolumes Optionally specify extra list of additional volumes
+## @param extraVolumes Optionally specify extra list of additional volumes (supports Helm templating)
 ## e.g.:
 ## extraVolumes:
 ## - name: scripts


### PR DESCRIPTION
similar to #220 allow templating on extraVolumes, allowing use to inject release specific files from configMaps.
An example usage is injecting a small dataset via `"--init-data-file=/dataset/dataset.cypherl"`
