### PR TITLE
fix: add fallback volume when PVC creation is disabled

### DIFF
--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -75,6 +75,15 @@ spec:
         {{- toYaml .Values.imagePullSecrets | nindent 4 }}
       {{- end }}
       volumes:
+      {{- if not .Values.persistentVolumeClaim.createStorageClaim }}
+        - name: {{ include "memgraph.fullname" . }}-lib-storage
+        {{- if .Values.persistentVolumeClaim.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistentVolumeClaim.existingClaim }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      {{- end }}
       {{- range .Values.customQueryModules }}
         - name: {{ .volume | quote }}
           configMap:


### PR DESCRIPTION
When `persistentVolumeClaim.createStorageClaim` is `false`, the `lib-storage` volumeMount was rendered without a corresponding volume definition, causing Kubernetes to reject the pod.

**Fix:** adds a volume entry in the `volumes:` section when `createStorageClaim=false`:
- Uses `existingClaim` PVC if set
- Falls back to `emptyDir` otherwise

From what I understand it could have been introduced by : https://github.com/memgraph/helm-charts/pull/12/changes

There's a couple of way to fix the issue, including adding a condition to the volume mount.
This pr needs a bit more review than my previous PR's I believe.