### PR TITLE
feat: Add optional log PVC

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -1,3 +1,6 @@
+{{- if and (not .Values.storage.coordinators.createLogStorageClaim) .Values.commonArgs.coordinators.logging.log_file }}
+{{- fail (printf "storage.coordinators.createLogStorageClaim is false but commonArgs.coordinators.logging.log_file is %q. Set commonArgs.coordinators.logging.log_file to \"\" to disable file logging, or set storage.coordinators.createLogStorageClaim to true." .Values.commonArgs.coordinators.logging.log_file) }}
+{{- end }}
 {{- range $index, $coordinator := .Values.coordinators }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -203,8 +206,10 @@ spec:
         volumeMounts:
           - name: memgraph-coordinator-{{ $coordinator.id }}-lib-storage
             mountPath: /var/lib/memgraph
+          {{- if $.Values.storage.coordinators.createLogStorageClaim }}
           - name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
             mountPath: /var/log/memgraph
+          {{- end }}
           - name: memgraph-coordinator-{{ $coordinator.id }}-tmp # Some Python libs require writing to tmp folder. Root filesystem set to read-only.
             mountPath: /tmp
           {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
@@ -266,7 +271,7 @@ spec:
         resources:
           requests:
             storage: {{ $.Values.storage.coordinators.libPVCSize }}
-
+    {{- if $.Values.storage.coordinators.createLogStorageClaim }}
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
@@ -278,6 +283,7 @@ spec:
         resources:
           requests:
             storage: {{ $.Values.storage.coordinators.logPVCSize }}
+    {{- end }}
 
     {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
     - apiVersion: v1

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -1,3 +1,6 @@
+{{- if and (not .Values.storage.data.createLogStorageClaim) .Values.commonArgs.data.logging.log_file }}
+{{- fail (printf "storage.data.createLogStorageClaim is false but commonArgs.data.logging.log_file is %q. Set commonArgs.data.logging.log_file to \"\" to disable file logging, or set storage.data.createLogStorageClaim to true." .Values.commonArgs.data.logging.log_file) }}
+{{- end }}
 {{- range $index, $data := .Values.data }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -200,8 +203,10 @@ spec:
         volumeMounts:
           - name: memgraph-data-{{ $data.id }}-lib-storage
             mountPath: /var/lib/memgraph
+          {{- if $.Values.storage.data.createLogStorageClaim }}
           - name: memgraph-data-{{ $data.id }}-log-storage
             mountPath: /var/log/memgraph
+          {{- end }}
           - name: memgraph-data-{{ $data.id }}-tmp # Some Python libs require writing to tmp folder. Root filesystem set to read-only.
             mountPath: /tmp
           {{- if $.Values.storage.data.createCoreDumpsClaim }}
@@ -262,6 +267,7 @@ spec:
         resources:
           requests:
             storage: {{ $.Values.storage.data.libPVCSize }}
+    {{- if $.Values.storage.data.createLogStorageClaim }}
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
@@ -273,7 +279,7 @@ spec:
         resources:
           requests:
             storage: {{ $.Values.storage.data.logPVCSize }}
-
+    {{- end }}
     {{- if $.Values.storage.data.createCoreDumpsClaim }}
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -12,6 +12,7 @@ storage:
     # By default the name of the storage class isn't set which means that the default storage class will be used.
     # If you set any name, such storage class must exist.
     libStorageClassName:
+    createLogStorageClaim: true
     logPVCSize: "1Gi"
     logStorageAccessMode: "ReadWriteOnce"
     logStorageClassName:
@@ -48,6 +49,7 @@ storage:
     # By default the name of the storage class isn't set which means that the default storage class will be used.
     # If you set any name, such storage class must exist.
     libStorageClassName:
+    createLogStorageClaim: true
     logPVCSize: "1Gi"
     logStorageAccessMode: "ReadWriteOnce"
     logStorageClassName:


### PR DESCRIPTION
Log volume would be used before even when log file wasn't not created (--log-file=""). The PR adds optional parameter to configure whether the log volume should be created or not. It is invalid configuration to use --log-file and not set log volume.