### PR TITLE
fix: Expose only probes' timings

### DIFF
--- a/charts/memgraph-high-availability/templates/_helpers.tpl
+++ b/charts/memgraph-high-availability/templates/_helpers.tpl
@@ -44,53 +44,58 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "container.data.readinessProbe" -}}
+{{- $p := .Values.container.data.readinessProbe -}}
 readinessProbe:
   tcpSocket:
-    port: {{ .tcpSocket.port }}
-  failureThreshold: {{ .failureThreshold }}
-  timeoutSeconds: {{ .timeoutSeconds }}
-  periodSeconds: {{ .periodSeconds }}
+    port: {{ .Values.ports.boltPort }}
+  failureThreshold: {{ $p.failureThreshold }}
+  timeoutSeconds: {{ $p.timeoutSeconds }}
+  periodSeconds: {{ $p.periodSeconds }}
 {{- end }}
 
 
 {{- define "container.data.livenessProbe" -}}
+{{- $p := .Values.container.data.livenessProbe -}}
 livenessProbe:
   tcpSocket:
-    port: {{ .tcpSocket.port }}
-  failureThreshold: {{ .failureThreshold }}
-  timeoutSeconds: {{ .timeoutSeconds }}
-  periodSeconds: {{ .periodSeconds }}
+    port: {{ .Values.ports.boltPort }}
+  failureThreshold: {{ $p.failureThreshold }}
+  timeoutSeconds: {{ $p.timeoutSeconds }}
+  periodSeconds: {{ $p.periodSeconds }}
 {{- end }}
 
 
 {{- define "container.data.startupProbe" -}}
+{{- $p := .Values.container.data.startupProbe -}}
 startupProbe:
   tcpSocket:
-    port: {{ .tcpSocket.port }}
-  failureThreshold: {{ .failureThreshold }}
-  timeoutSeconds: {{ .timeoutSeconds }}
-  periodSeconds: {{ .periodSeconds }}
+    port: {{ .Values.ports.boltPort }}
+  failureThreshold: {{ $p.failureThreshold }}
+  timeoutSeconds: {{ $p.timeoutSeconds }}
+  periodSeconds: {{ $p.periodSeconds }}
 {{- end }}
 
 
 
 {{- define "container.coordinators.readinessProbe" -}}
+{{- $p := .Values.container.coordinators.readinessProbe -}}
 readinessProbe:
   tcpSocket:
-    port: {{ .tcpSocket.port }}
-  failureThreshold: {{ .failureThreshold }}
-  timeoutSeconds: {{ .timeoutSeconds }}
-  periodSeconds: {{ .periodSeconds }}
+    port: {{ .Values.ports.coordinatorPort }}
+  failureThreshold: {{ $p.failureThreshold }}
+  timeoutSeconds: {{ $p.timeoutSeconds }}
+  periodSeconds: {{ $p.periodSeconds }}
 {{- end }}
 
 
 {{- define "container.coordinators.livenessProbe" -}}
+{{- $p := .Values.container.coordinators.livenessProbe -}}
 livenessProbe:
   tcpSocket:
-    port: {{ .tcpSocket.port }}
-  failureThreshold: {{ .failureThreshold }}
-  timeoutSeconds: {{ .timeoutSeconds }}
-  periodSeconds: {{ .periodSeconds }}
+    port: {{ .Values.ports.coordinatorPort }}
+  failureThreshold: {{ $p.failureThreshold }}
+  timeoutSeconds: {{ $p.timeoutSeconds }}
+  periodSeconds: {{ $p.periodSeconds }}
 {{- end }}
 
 
@@ -107,12 +112,13 @@ livenessProbe:
 
 
 {{- define "container.coordinators.startupProbe" -}}
+{{- $p := .Values.container.coordinators.startupProbe -}}
 startupProbe:
   tcpSocket:
-    port: {{ .tcpSocket.port }}
-  failureThreshold: {{ .failureThreshold }}
-  timeoutSeconds: {{ .timeoutSeconds }}
-  periodSeconds: {{ .periodSeconds }}
+    port: {{ .Values.ports.coordinatorPort }}
+  failureThreshold: {{ $p.failureThreshold }}
+  timeoutSeconds: {{ $p.timeoutSeconds }}
+  periodSeconds: {{ $p.periodSeconds }}
 {{- end }}
 
 

--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -229,9 +229,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           # Run by 'memgraph' user as specified in the Dockerfile
-        {{- include "container.coordinators.readinessProbe" $.Values.container.coordinators.readinessProbe | nindent 8 }}
-        {{- include "container.coordinators.livenessProbe" $.Values.container.coordinators.livenessProbe | nindent 8 }}
-        {{- include "container.coordinators.startupProbe" $.Values.container.coordinators.startupProbe | nindent 8 }}
+        {{- include "container.coordinators.readinessProbe" $ | nindent 8 }}
+        {{- include "container.coordinators.livenessProbe" $ | nindent 8 }}
+        {{- include "container.coordinators.startupProbe" $ | nindent 8 }}
         {{- with $.Values.resources.coordinators }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -225,9 +225,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           # Run by 'memgraph' user as specified in the Dockerfile
-        {{- include "container.data.readinessProbe" $.Values.container.data.readinessProbe | nindent 8 }}
-        {{- include "container.data.livenessProbe" $.Values.container.data.livenessProbe | nindent 8 }}
-        {{- include "container.data.startupProbe" $.Values.container.data.startupProbe | nindent 8 }}
+        {{- include "container.data.readinessProbe" $ | nindent 8 }}
+        {{- include "container.data.livenessProbe" $ | nindent 8 }}
+        {{- include "container.data.startupProbe" $ | nindent 8 }}
         {{- with $.Values.resources.data }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -82,10 +82,10 @@ storage:
     #     readOnly: true
 
 ports:
-  boltPort: 7687 # If you change this value, change it also in probes definition
+  boltPort: 7687
   managementPort: 10000
   replicationPort: 20000
-  coordinatorPort: 12000 # If you change this value, change it also in probes definition
+  coordinatorPort: 12000
   metricsPort: 9091
 
 externalAccessConfig:
@@ -168,43 +168,33 @@ container:
   data:
     terminationGracePeriodSeconds: 30 # Make sure to increase this value if --storage-snapshot-on-exit=true so that snapshot can be successfully created on exit. The concrete value depends
     # on the amount of data in your database
+    # Probes are hard-coded to tcpSocket against ports.boltPort. Only timings below are configurable.
     readinessProbe:
-      tcpSocket:
-        port: 7687 # If you change bolt port, change this also
       failureThreshold: 20
       timeoutSeconds: 10
       periodSeconds: 5
     livenessProbe:
-      tcpSocket:
-        port: 7687 # If you change bolt port, change this also
       failureThreshold: 20
       timeoutSeconds: 10
       periodSeconds: 5
     # When restoring Memgraph from a backup, it is important to give enough time app to start. Here, we set it to 2h by default.
     startupProbe:
-      tcpSocket:
-        port: 7687 # If you change bolt port, change this also
       failureThreshold: 1440
       timeoutSeconds: 10
       periodSeconds: 5
   coordinators:
     terminationGracePeriodSeconds: 30 # Make sure to increase this value if --storage-snapshot-on-exit=true so that snapshot can be successfully created on exit. The concrete value depends
     # on the amount of data in your databas
+    # Probes are hard-coded to tcpSocket against ports.coordinatorPort. Only timings below are configurable.
     readinessProbe:
-      tcpSocket:
-        port: 12000 # If you change coordinator port, change this also
       failureThreshold: 20
       timeoutSeconds: 10
       periodSeconds: 5
     livenessProbe:
-      tcpSocket:
-        port: 12000 # If you change coordinator port, change this also
       failureThreshold: 20
       timeoutSeconds: 10
       periodSeconds: 5
     startupProbe:
-      tcpSocket:
-        port: 12000
       failureThreshold: 20
       timeoutSeconds: 10
       periodSeconds: 5


### PR DESCRIPTION
Hard-code tcpSocket + port used for probes