### PR TITLE
Bump charts for version 3.10

### DIFF
--- a/.github/workflows/lint-test-memgraph-lab.yaml
+++ b/.github/workflows/lint-test-memgraph-lab.yaml
@@ -53,4 +53,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --excluded-charts memgraph-high-availability, memgraph, memgraph-mcp
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --excluded-charts memgraph-high-availability,memgraph,memgraph-mcp

--- a/.github/workflows/lint-test-memgraph.yml
+++ b/.github/workflows/lint-test-memgraph.yml
@@ -68,4 +68,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set secrets.enabled=true" --excluded-charts memgraph-high-availability, memgraph-lab, memgraph-mcp --namespace default
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set secrets.enabled=true" --excluded-charts memgraph-high-availability,memgraph-lab,memgraph-mcp --namespace default

--- a/charts/memgraph-high-availability/Chart.yaml
+++ b/charts/memgraph-high-availability/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: memgraph-high-availability
 description: A Helm chart for Kubernetes with Memgraph High availabiliy capabilites
 
-version: 0.2.19
-appVersion: "3.9.0"
+version: 1.0.0
+appVersion: "3.10.0"
 
 type: application
 

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: docker.io/memgraph/memgraph
   # It is a bad practice to set the image tag name to 'latest' as it can trigger automatic upgrade of the charts
   # With some of the pullPolicy values. Please consider fixing the tag to a specific Memgraph version
-  tag: 3.9.0
+  tag: 3.10.0
   pullPolicy: IfNotPresent
 
 storage:

--- a/charts/memgraph-lab/Chart.yaml
+++ b/charts/memgraph-lab/Chart.yaml
@@ -3,10 +3,10 @@ name: memgraph-lab
 home: https://memgraph.com/
 type: application
 # Chart version, should be incremented each time the chart changes, including appVersion.
-version: 0.1.16
+version: 1.0.0
 # Version number of the docker image memgraph/lab.
 # Use it with quotes.
-appVersion: "3.9.0"
+appVersion: "3.10.0"
 description: Memgraph Lab Helm Chart
 keywords:
 - graph

--- a/charts/memgraph-mcp/Chart.yaml
+++ b/charts/memgraph-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memgraph-mcp
 home: https://memgraph.com
 type: application
-version: 0.1.0
+version: 1.0.0
 appVersion: 0.1.13
 description: Helm Chart for Memgraph's MCP server
 keywords:

--- a/charts/memgraph/Chart.yaml
+++ b/charts/memgraph/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: memgraph
 home: https://memgraph.com/
 type: application
-version: 0.2.19
-appVersion: "3.9.0"
+version: 1.0.0
+appVersion: "3.10.0"
 description: MemgraphDB Helm Chart
 keywords:
 - graph


### PR DESCRIPTION
Bump chart versions to `1.0.0` for the `3.10` release of Memgraph and Lab
