### PR TITLE
feat: Manually chown in the case when fsGroup not respected

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -127,6 +127,44 @@ spec:
           runAsNonRoot: false
       {{- end }}
 
+      {{- if $.Values.fixOwnershipInitContainer.enabled }}
+      - name: init-fix-perms
+        image: "{{ $.Values.fixOwnershipInitContainer.image.repository }}:{{ $.Values.fixOwnershipInitContainer.image.tag }}"
+        imagePullPolicy: {{ $.Values.fixOwnershipInitContainer.image.pullPolicy }}
+        command: ['/bin/sh', '-c']
+        args:
+          - |
+            set -e
+            chown -R {{ $.Values.memgraphUserId }}:{{ $.Values.memgraphGroupId }} /var/lib/memgraph
+            {{- if $.Values.storage.coordinators.createLogStorageClaim }}
+            chown -R {{ $.Values.memgraphUserId }}:{{ $.Values.memgraphGroupId }} /var/log/memgraph
+            {{- end }}
+            {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
+            chown -R {{ $.Values.memgraphUserId }}:{{ $.Values.memgraphGroupId }} {{ $.Values.storage.coordinators.coreDumpsMountPath }}
+            {{- end }}
+        securityContext:
+          runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN"]
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+          - name: memgraph-coordinator-{{ $coordinator.id }}-lib-storage
+            mountPath: /var/lib/memgraph
+          {{- if $.Values.storage.coordinators.createLogStorageClaim }}
+          - name: memgraph-coordinator-{{ $coordinator.id }}-log-storage
+            mountPath: /var/log/memgraph
+          {{- end }}
+          {{- if $.Values.storage.coordinators.createCoreDumpsClaim }}
+          - name: memgraph-coordinator-{{ $coordinator.id }}-core-dumps-storage
+            mountPath: {{ $.Values.storage.coordinators.coreDumpsMountPath }}
+          {{- end }}
+      {{- end }}
+
       {{- with $.Values.initContainers.coordinators }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -136,6 +136,44 @@ spec:
           runAsNonRoot: false
       {{- end }}
 
+      {{- if $.Values.fixOwnershipInitContainer.enabled }}
+      - name: init-fix-perms
+        image: "{{ $.Values.fixOwnershipInitContainer.image.repository }}:{{ $.Values.fixOwnershipInitContainer.image.tag }}"
+        imagePullPolicy: {{ $.Values.fixOwnershipInitContainer.image.pullPolicy }}
+        command: ['/bin/sh', '-c']
+        args:
+          - |
+            set -e
+            chown -R {{ $.Values.memgraphUserId }}:{{ $.Values.memgraphGroupId }} /var/lib/memgraph
+            {{- if $.Values.storage.data.createLogStorageClaim }}
+            chown -R {{ $.Values.memgraphUserId }}:{{ $.Values.memgraphGroupId }} /var/log/memgraph
+            {{- end }}
+            {{- if $.Values.storage.data.createCoreDumpsClaim }}
+            chown -R {{ $.Values.memgraphUserId }}:{{ $.Values.memgraphGroupId }} {{ $.Values.storage.data.coreDumpsMountPath }}
+            {{- end }}
+        securityContext:
+          runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN"]
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+          - name: memgraph-data-{{ $data.id }}-lib-storage
+            mountPath: /var/lib/memgraph
+          {{- if $.Values.storage.data.createLogStorageClaim }}
+          - name: memgraph-data-{{ $data.id }}-log-storage
+            mountPath: /var/log/memgraph
+          {{- end }}
+          {{- if $.Values.storage.data.createCoreDumpsClaim }}
+          - name: memgraph-data-{{ $data.id }}-core-dumps-storage
+            mountPath: {{ $.Values.storage.data.coreDumpsMountPath }}
+          {{- end }}
+      {{- end }}
+
       {{- with $.Values.initContainers.data }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -23,7 +23,7 @@ storage:
     coreDumpsMountPath: /var/core/memgraph
     coreDumpsImage:
       repository: docker.io/library/busybox
-      tag: latest
+      tag: 1.37.0
       pullPolicy: IfNotPresent
     # Supports Helm templating (e.g. {{ .Release.Name }})
     extraVolumes: []
@@ -60,7 +60,7 @@ storage:
     coreDumpsMountPath: /var/core/memgraph
     coreDumpsImage:
       repository: docker.io/library/busybox
-      tag: latest
+      tag: 1.37.0
       pullPolicy: IfNotPresent
     # Supports Helm templating (e.g. {{ .Release.Name }})
     extraVolumes: []
@@ -141,7 +141,7 @@ sysctlInitContainer:
   maxMapCount: 262144
   image:
     repository: docker.io/library/busybox
-    tag: latest
+    tag: 1.37.0
     pullPolicy: IfNotPresent
 
 # Some storage drivers (notably rancher.io/local-path) do not honor pod-level fsGroup,
@@ -154,7 +154,7 @@ fixOwnershipInitContainer:
   enabled: false
   image:
     repository: docker.io/library/busybox
-    tag: latest
+    tag: 1.37.0
     pullPolicy: IfNotPresent
 
 # This is fine because under both
@@ -414,7 +414,7 @@ userContainers:
   # Example:
   # coordinators:
   #  - name: my-debugger
-  #    image: docker.io/library/busybox:latest
+  #    image: docker.io/library/busybox:1.37.0
   #    command: ["sh", "-c", "echo hi; sleep 10000"]
 
 coreDumpUploader:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -144,6 +144,19 @@ sysctlInitContainer:
     tag: latest
     pullPolicy: IfNotPresent
 
+# Some storage drivers (notably rancher.io/local-path) do not honor pod-level fsGroup,
+# leaving the volume root owned by root:root. Because Memgraph runs as a non-root user,
+# its storage directory ownership assertion (process euid == data directory owner uid)
+# fails on startup. When enabled, an init container runs as root and chowns the lib,
+# log, and core-dumps mount points to memgraphUserId:memgraphGroupId before Memgraph
+# starts
+fixOwnershipInitContainer:
+  enabled: false
+  image:
+    repository: docker.io/library/busybox
+    tag: latest
+    pullPolicy: IfNotPresent
+
 # This is fine because under both
 # Memgraph and Mage images we actually hard-code the user and group id.
 memgraphUserId: 101


### PR DESCRIPTION
Some storage classes don't support fsGroup. In that case, user should manually chown on the volumes used. This feature allows easier chown by just setting a switch. Inspired by [mysql-operator](https://github.com/bitpoke/mysql-operator/pull/734/changes).