### PR TITLE
feat: allow templating in secrets.name

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -225,12 +225,12 @@ spec:
           - name: MEMGRAPH_ENTERPRISE_LICENSE
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.secrets.name }}
+                name: {{ tpl $.Values.secrets.name $ }}
                 key: {{ $.Values.secrets.licenseKey }}
           - name: MEMGRAPH_ORGANIZATION_NAME
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.secrets.name }}
+                name: {{ tpl $.Values.secrets.name $ }}
                 key: {{ $.Values.secrets.organizationKey }}
           - name: DGL_DOWNLOAD_DIR # DGL by default writes to /home/memgraph which we set to be read-only
             value: /tmp/.dgl

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -222,12 +222,12 @@ spec:
           - name: MEMGRAPH_ENTERPRISE_LICENSE
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.secrets.name }}
+                name: {{ tpl $.Values.secrets.name $ }}
                 key: {{ $.Values.secrets.licenseKey }}
           - name: MEMGRAPH_ORGANIZATION_NAME
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.secrets.name }}
+                name: {{ tpl $.Values.secrets.name $ }}
                 key: {{ $.Values.secrets.organizationKey }}
           - name: DGL_DOWNLOAD_DIR # DGL by default writes to /home/memgraph which we set to be read-only
             value: /tmp/.dgl

--- a/charts/memgraph-lab/templates/deployment.yaml
+++ b/charts/memgraph-lab/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: {{ . }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.Values.secrets.name }}
+                  name: {{ tpl $.Values.secrets.name $ }}
                   key: {{ . }}
             {{- end }}
             {{- end }}

--- a/charts/memgraph/templates/statefulset.yaml
+++ b/charts/memgraph/templates/statefulset.yaml
@@ -136,12 +136,12 @@ spec:
             - name: MEMGRAPH_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secrets.name }}
+                  name: {{ tpl .Values.secrets.name . }}
                   key: {{ .Values.secrets.userKey }}
             - name: MEMGRAPH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secrets.name }}
+                  name: {{ tpl .Values.secrets.name . }}
                   key: {{ .Values.secrets.passwordKey }}
            {{- end }}
            {{ if .Values.memgraphEnterpriseLicense }}


### PR DESCRIPTION
## Summary

Allow Go template expressions in `secrets.name` values by wrapping references with the `tpl` function.

### Example

```yaml
secrets:
  enabled: true
  name: "{{ .Release.Name }}-secrets"
```

### Changes

Uses `tpl` for `secrets.name` in:
- `charts/memgraph/templates/statefulset.yaml`
- `charts/memgraph-lab/templates/deployment.yaml`
- `charts/memgraph-high-availability/templates/coordinators.yaml`
- `charts/memgraph-high-availability/templates/data.yaml`

Plain string values (e.g. `memgraph-secrets`) continue to work unchanged.

### Validation

All three charts verified with `helm template`:
- Templated name (`{{ .Release.Name }}-secrets`) resolves correctly
- Default plain string values render as before