### PR TITLE
fix: template mg-exporter names with release fullname

### DIFF
--- a/charts/memgraph-high-availability/templates/_helpers.tpl
+++ b/charts/memgraph-high-availability/templates/_helpers.tpl
@@ -43,6 +43,20 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Create the name for mg-exporter resources.
+*/}}
+{{- define "memgraph.mgExporterName" -}}
+{{- printf "%s-mg-exporter" (include "memgraph.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create the config map name for mg-exporter resources.
+*/}}
+{{- define "memgraph.mgExporterConfigName" -}}
+{{- printf "%s-config" (include "memgraph.mgExporterName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
 {{- define "container.data.readinessProbe" -}}
 {{- $p := .Values.container.data.readinessProbe -}}
 readinessProbe:

--- a/charts/memgraph-high-availability/templates/mg-exporter.yaml
+++ b/charts/memgraph-high-availability/templates/mg-exporter.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mg-exporter-config
+  name: {{ include "memgraph.mgExporterConfigName" $ }}
   namespace: {{ $.Values.prometheus.namespace | default $.Release.Namespace }}
 data:
   ha_config.yaml: |
@@ -26,15 +26,15 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraph.mgExporterName" $ }}
   namespace: {{ $.Values.prometheus.namespace | default $.Release.Namespace }}
   labels:
-    app: mg-exporter
+    app: {{ include "memgraph.mgExporterName" $ }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mg-exporter
+      app: {{ include "memgraph.mgExporterName" $ }}
   template:
     metadata:
       # Force Deployment rollout when HA exporter inputs change. The exporter
@@ -42,7 +42,7 @@ spec:
       annotations:
         checksum/ha-config: {{ printf "%s-%s-%s" (toJson $.Values.coordinators) (toJson $.Values.data) (toJson $.Values.prometheus.memgraphExporter) | sha256sum }}
       labels:
-        app: mg-exporter
+        app: {{ include "memgraph.mgExporterName" $ }}
     spec:
       containers:
         - name: exporter
@@ -64,7 +64,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: mg-exporter-config
+            name: {{ include "memgraph.mgExporterConfigName" $ }}
         {{- with $.Values.prometheus.memgraphExporter.extraVolumes }}
         {{- toYaml $.Values.prometheus.memgraphExporter.extraVolumes | nindent 8 }}
         {{- end }}
@@ -72,13 +72,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraph.mgExporterName" $ }}
   namespace: {{ $.Values.prometheus.namespace | default $.Release.Namespace }}
   labels:
-    app: mg-exporter
+    app: {{ include "memgraph.mgExporterName" $ }}
 spec:
   selector:
-    app: mg-exporter
+    app: {{ include "memgraph.mgExporterName" $ }}
   ports:
     - protocol: TCP
       name: tcp-metrics-port
@@ -89,14 +89,14 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraph.mgExporterName" $ }}
   namespace: {{ $.Values.prometheus.namespace | default $.Release.Namespace }}
   labels:
     release: {{ $.Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
 spec:
   selector:
     matchLabels:
-      app: mg-exporter
+      app: {{ include "memgraph.mgExporterName" $ }}
   endpoints:
     - port: tcp-metrics-port  # must be the same as the service port name
       interval: {{ $.Values.prometheus.serviceMonitor.interval }}

--- a/charts/memgraph/templates/_helpers.tpl
+++ b/charts/memgraph/templates/_helpers.tpl
@@ -61,6 +61,20 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Create the name for mg-exporter resources.
+*/}}
+{{- define "memgraph.mgExporterName" -}}
+{{- printf "%s-mg-exporter" (include "memgraph.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create the config map name for mg-exporter resources.
+*/}}
+{{- define "memgraph.mgExporterConfigName" -}}
+{{- printf "%s-config" (include "memgraph.mgExporterName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
 {{- define "container.readinessProbe" -}}
 readinessProbe:
 {{- if .exec }}

--- a/charts/memgraph/templates/mg-exporter.yaml
+++ b/charts/memgraph/templates/mg-exporter.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mg-exporter-config
+  name: {{ include "memgraph.mgExporterConfigName" . }}
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
 data:
   standalone_config.yaml: |
@@ -17,19 +17,19 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraph.mgExporterName" . }}
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
-    app: mg-exporter
+    app: {{ include "memgraph.mgExporterName" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mg-exporter
+      app: {{ include "memgraph.mgExporterName" . }}
   template:
     metadata:
       labels:
-        app: mg-exporter
+        app: {{ include "memgraph.mgExporterName" . }}
     spec:
       containers:
         - name: exporter
@@ -48,18 +48,18 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: mg-exporter-config
+            name: {{ include "memgraph.mgExporterConfigName" . }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraph.mgExporterName" . }}
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
-    app: mg-exporter
+    app: {{ include "memgraph.mgExporterName" . }}
 spec:
   selector:
-    app: mg-exporter
+    app: {{ include "memgraph.mgExporterName" . }}
   ports:
     - protocol: TCP
       name: tcp-metrics-port
@@ -70,14 +70,14 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: mg-exporter
+  name: {{ include "memgraph.mgExporterName" . }}
   namespace: {{ .Values.prometheus.namespace | default .Release.Namespace }}
   labels:
     release: {{ .Values.prometheus.serviceMonitor.kubePrometheusStackReleaseName }}
 spec:
   selector:
     matchLabels:
-      app: mg-exporter
+      app: {{ include "memgraph.mgExporterName" . }}
   endpoints:
     - port: tcp-metrics-port  # must be the same as the service port name
       interval: {{ .Values.prometheus.serviceMonitor.interval }}


### PR DESCRIPTION
Template `mg-exporter` resource names with release-scoped fullnames in both `memgraph` and `memgraph-high-availability` charts, and update related selectors/references so multiple releases can coexist in the same namespace. Also validated with `helm lint` and `helm template` before and after the change.

___

### Tracking
- [x] **[Link to Epic/Issue]** https://github.com/memgraph/helm-charts/issues/233 (issue describes mg-exporter naming collision)

