### PR TITLE
feat: Add support for cluster-setup labels and securityContext

### DIFF
--- a/charts/memgraph-high-availability/templates/cluster-setup.yaml
+++ b/charts/memgraph-high-availability/templates/cluster-setup.yaml
@@ -7,13 +7,30 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- with .Values.clusterSetup.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
+    {{- with .Values.clusterSetup.labels }}
+    metadata:
+      labels:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       restartPolicy: Never
+      {{- with .Values.clusterSetup.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: cluster-setup
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          {{- with .Values.clusterSetup.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -194,7 +194,7 @@ clusterSetup:
   containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
-      drop: [ "ALL" ]
+      drop: ["ALL"]
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     seccompProfile:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -178,6 +178,28 @@ labels:
     statefulSetLabels: {}
     serviceLabels: {}
 
+# Configuration for the post-install cluster-setup Job. This Job runs as a Helm
+# post-install hook and registers all coordinators and data instances via mgconsole.
+clusterSetup:
+  # Custom labels applied to both the cluster-setup Job and its pod template.
+  labels: {}
+  # Pod-level security context for the cluster-setup Job pod.
+  podSecurityContext:
+    runAsUser: 101
+    runAsGroup: 103
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  # Container-level security context for the cluster-setup container.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ "ALL" ]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
 container:
   data:
     terminationGracePeriodSeconds: 30 # Make sure to increase this value if --storage-snapshot-on-exit=true so that snapshot can be successfully created on exit. The concrete value depends


### PR DESCRIPTION
### Tracking
- [ ] **[Link to Epic/Issue]**

### Standard development
- [x] Update / add chart templates, values, and `NOTES.txt` as needed
- [x] Run `helm lint` and `helm template` locally against the changed chart(s)
- [x] Verify the chart installs and upgrades cleanly on a test cluster

### Labels checklist
- [x] Add a docs label (exactly one): `docs-changelog-only`, `docs-needed`, or `docs-not-needed`
- [x] Add at least one component label: `memgraph`, `memgraph-ha`, `memgraph-lab`, or `infrastructure`
- [x] Add at least one type label: `bug`, `feature`, or `infrastructure`
- [x] Assign the PR to a milestone
    - If not known, set for a later milestone

### Documentation checklist
- [x] Write a release note, including added/changed clauses
    - Users can now set custom labels and security context for `clusterSetup` post-install hook. [#259](https://github.com/memgraph/helm-charts/pull/259)
- [x] **[ Documentation PR link ](https://github.com/memgraph/documentation/pull/1673)**
    - [x] Is back linked to this development PR
