### PR TITLE
fix: Hard-coded metrics port on the standalone chart

### DIFF
--- a/charts/memgraph/templates/mg-exporter.yaml
+++ b/charts/memgraph/templates/mg-exporter.yaml
@@ -10,7 +10,7 @@ data:
       port: {{ .Values.prometheus.memgraphExporter.port }}
     memgraph:
       endpoint_url: http://{{ include "memgraph.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-      port: 9091
+      port: {{ .Values.service.httpPortMonitoring }}
     general:
       pull_frequency_seconds: {{ .Values.prometheus.memgraphExporter.pullFrequencySeconds }}
 ---


### PR DESCRIPTION
Uses predefined configuration variable instead of the hard-coded 9091 port.