### PR TITLE
fix: harden release note generation

### DIFF
--- a/.github/scripts/test_release_notes.py
+++ b/.github/scripts/test_release_notes.py
@@ -78,7 +78,10 @@ def main() -> int:
     prs: dict[int, dict] = {}
     notes: dict[int, str | None] = {}
     for pr_number in pr_numbers:
-        prs[pr_number] = fetch_pr(repo, pr_number, token)
+        pr = fetch_pr(repo, pr_number, token)
+        if pr is None:
+            continue
+        prs[pr_number] = pr
         notes[pr_number] = next(
             (n for n in (find_release_note(b) for b in fetch_pr_comment_bodies(repo, pr_number, token)) if n),
             None,
@@ -87,7 +90,10 @@ def main() -> int:
     for chart, component_label in CHART_LABELS.items():
         grouped: dict[str, list[str]] = defaultdict(list)
         for pr_number in pr_numbers:
-            labels = [l["name"] for l in prs[pr_number].get("labels", [])]
+            pr = prs.get(pr_number)
+            if pr is None:
+                continue
+            labels = [l["name"] for l in pr.get("labels", [])]
             if component_label not in labels:
                 continue
             type_label = primary_type(labels)

--- a/.github/scripts/update_release_notes.py
+++ b/.github/scripts/update_release_notes.py
@@ -18,6 +18,7 @@ import os
 import re
 import subprocess
 import sys
+import urllib.error
 from collections import defaultdict
 
 from _common import find_release_note, github_request, paginate
@@ -32,7 +33,10 @@ TYPE_SECTIONS = [
     ("bug", "Bug fixes"),
     ("infrastructure", "Infrastructure"),
 ]
-PR_REF = re.compile(r"\(#(\d+)\)")
+# Squash-merges append the PR number as the last "(#N)" on the subject line.
+# Anchor to end-of-line so issue refs embedded in the PR title (e.g.
+# "fix foo (#233) (#261)") are not mistaken for the PR number.
+PR_REF = re.compile(r"\(#(\d+)\)\s*$")
 
 
 def parse_tag(tag: str) -> tuple[str, str] | None:
@@ -95,17 +99,26 @@ def extract_pr_numbers(commits: list[dict]) -> list[int]:
         message = commit.get("commit", {}).get("message", "")
         # Only look at the first line (squash-merge PR refs are in the subject).
         subject = message.split("\n", 1)[0]
-        for match in PR_REF.finditer(subject):
-            n = int(match.group(1))
-            if n not in seen:
-                seen.add(n)
-                ordered.append(n)
+        match = PR_REF.search(subject)
+        if not match:
+            continue
+        n = int(match.group(1))
+        if n not in seen:
+            seen.add(n)
+            ordered.append(n)
     return ordered
 
 
-def fetch_pr(repo: str, pr_number: int, token: str) -> dict:
-    with github_request(f"https://api.github.com/repos/{repo}/pulls/{pr_number}", token) as resp:
-        return json.loads(resp.read())
+def fetch_pr(repo: str, pr_number: int, token: str) -> dict | None:
+    try:
+        with github_request(f"https://api.github.com/repos/{repo}/pulls/{pr_number}", token) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            # Not a pull request (e.g. an issue ref that leaked through); skip.
+            print(f"  #{pr_number}: not a pull request (404); skipping")
+            return None
+        raise
 
 
 def fetch_pr_comment_bodies(repo: str, pr_number: int, token: str) -> list[str]:
@@ -154,6 +167,8 @@ def process_tag(tag: str, repo: str, token: str, all_tags: list[str]) -> None:
     grouped: dict[str, list[str]] = defaultdict(list)
     for pr_number in pr_numbers:
         pr = fetch_pr(repo, pr_number, token)
+        if pr is None:
+            continue
         labels = [l["name"] for l in pr.get("labels", [])]
         if component_label not in labels:
             continue


### PR DESCRIPTION
A recent release workflow run failed due to the title of [this PR](https://github.com/memgraph/helm-charts/pull/261) containing issue number it resolved. The resulting commit that gets parsed for PR numbers is titled: `fix: prefix mg-exporter resources with release fullname (#233) (#261)`. The script for building the changelog items matched both numbers in the title and failed to find the PR #233. This fix should match only the last number found in a title and also handle the 404 received when it cannot fetch the PR.
