### PR TITLE
feat: Integrate External DNS with LoadBalancer service type

### DIFF
--- a/charts/memgraph-high-availability/templates/NOTES.txt
+++ b/charts/memgraph-high-availability/templates/NOTES.txt
@@ -4,19 +4,4 @@ You can find information about installing this chart on Memgraph docs https://me
 {{- if .Values.externalAccessConfig.gateway.enabled }}
 
 Gateway API external access is enabled.
-{{- if .Values.externalAccessConfig.gateway.existingGatewayName }}
-Using existing Gateway: {{ .Values.externalAccessConfig.gateway.existingGatewayName }}
-{{- else }}
-Gateway: {{ include "memgraph.fullname" . }}-gateway (GatewayClass: {{ .Values.externalAccessConfig.gateway.gatewayClassName }})
-{{- end }}
-
-Data instance ports:
-{{- range $index, $data := .Values.data }}
-  memgraph-data-{{ $data.id }}: {{ add (int $.Values.externalAccessConfig.gateway.dataPortBase) (int $data.id) }}
-{{- end }}
-
-Coordinator instance ports:
-{{- range .Values.coordinators }}
-  memgraph-coordinator-{{ .id }}: {{ add (int $.Values.externalAccessConfig.gateway.coordinatorPortBase) (int .id) }}
-{{- end }}
 {{- end }}

--- a/charts/memgraph-high-availability/templates/_helpers.tpl
+++ b/charts/memgraph-high-availability/templates/_helpers.tpl
@@ -40,9 +40,12 @@ it triggers at template time (helm template / lint), not only when the
 cluster-setup hook runs.
 */}}
 {{- define "memgraph.validateExternalAccess" -}}
-{{- $ingressNginx := or (eq .Values.externalAccessConfig.dataInstance.serviceType "IngressNginx") (eq .Values.externalAccessConfig.coordinator.serviceType "IngressNginx") -}}
-{{- if and $ingressNginx .Values.externalAccessConfig.gateway.enabled -}}
-{{- fail "IngressNginx serviceType (externalAccessConfig.dataInstance/coordinator.serviceType) and externalAccessConfig.gateway.enabled are mutually exclusive; use only one." -}}
+{{- if .Values.externalAccessConfig.gateway.enabled -}}
+{{- $dataHasServiceType := ne (.Values.externalAccessConfig.dataInstance.serviceType | default "") "" -}}
+{{- $coordHasServiceType := ne (.Values.externalAccessConfig.coordinator.serviceType | default "") "" -}}
+{{- if and $dataHasServiceType $coordHasServiceType -}}
+{{- fail "externalAccessConfig.gateway.enabled requires at least one tier without a serviceType: a tier with dataInstance/coordinator.serviceType set is excluded from the Gateway, so with both set the Gateway would apply to nothing. Unset one serviceType or disable the gateway." -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/memgraph-high-availability/templates/cluster-setup.yaml
+++ b/charts/memgraph-high-availability/templates/cluster-setup.yaml
@@ -19,6 +19,11 @@
   externalAccessAnnotations (merged with the tier annotations, per-instance
   winning — the same merge the external service templates apply) at the shared
   bolt port. NodePort keeps the internal bolt_server.
+
+  The gateway only applies to a tier whose serviceType is EMPTY — a tier with a
+  serviceType set gets its external access from that service type instead
+  (validation fails the render when gateway.enabled and both tiers have a
+  serviceType, since the Gateway would then apply to nothing).
 */}}
 {{/*
   Per instance the external port is either unique (IngressNginx / gateway give
@@ -45,7 +50,7 @@
 {{- if eq .Values.externalAccessConfig.dataInstance.serviceType "IngressNginx" }}
   {{- $dataExternalHost = $ingressHost }}
   {{- $dataExternalPortBase = int .Values.externalAccessConfig.ingress.dataPortBase }}
-{{- else if .Values.externalAccessConfig.gateway.enabled }}
+{{- else if and .Values.externalAccessConfig.gateway.enabled (eq .Values.externalAccessConfig.dataInstance.serviceType "") }}
   {{- $dataExternalHost = index (.Values.externalAccessConfig.gateway.annotations | default dict) "external-dns.alpha.kubernetes.io/hostname" | default "" }}
   {{- $dataExternalPortBase = int .Values.externalAccessConfig.gateway.dataPortBase }}
 {{- end }}
@@ -57,7 +62,7 @@
          coordinator is reached at the same hostname:boltPort. */}}
   {{- $coordExternalHost = index (.Values.externalAccessConfig.coordinator.annotations | default dict) "external-dns.alpha.kubernetes.io/hostname" | default "" }}
   {{- $coordExternalPort = int .Values.ports.boltPort }}
-{{- else if .Values.externalAccessConfig.gateway.enabled }}
+{{- else if and .Values.externalAccessConfig.gateway.enabled (eq .Values.externalAccessConfig.coordinator.serviceType "") }}
   {{- $coordExternalHost = index (.Values.externalAccessConfig.gateway.annotations | default dict) "external-dns.alpha.kubernetes.io/hostname" | default "" }}
   {{- $coordExternalPortBase = int .Values.externalAccessConfig.gateway.coordinatorPortBase }}
 {{- end }}

--- a/charts/memgraph-high-availability/templates/cluster-setup.yaml
+++ b/charts/memgraph-high-availability/templates/cluster-setup.yaml
@@ -13,13 +13,18 @@
   service type + external-dns hostname, and coordinators use the coordinator
   tier's own — the two can differ (e.g. data via IngressNginx, coordinators via
   CommonLoadBalancer). Only IngressNginx/gateway give each instance a unique
-  external port; CommonLoadBalancer/LoadBalancer/NodePort keep the internal
-  bolt_server (a shared LB can't address individual instances by port).
+  external port; CommonLoadBalancer shares one hostname:boltPort across all
+  coordinators; LoadBalancer gives each instance its own LB Service, so its
+  hostname is resolved PER INSTANCE from the instance's
+  externalAccessAnnotations (merged with the tier annotations, per-instance
+  winning — the same merge the external service templates apply) at the shared
+  bolt port. NodePort keeps the internal bolt_server.
 */}}
 {{/*
   Per instance the external port is either unique (IngressNginx / gateway give
-  portBase + id) or a single shared port (CommonLoadBalancer / LoadBalancer put
-  every instance behind one bolt port). $*ExternalPort, when > 0, is that shared
+  portBase + id) or a single shared port (CommonLoadBalancer puts every
+  coordinator behind one bolt port; a per-instance LoadBalancer exposes its
+  instance on the bolt port too). $*ExternalPort, when > 0, is that shared
   fixed port and takes precedence over $*ExternalPortBase + id in the loops below.
 */}}
 {{- $dataExternalHost := "" }}
@@ -56,6 +61,15 @@
   {{- $coordExternalHost = index (.Values.externalAccessConfig.gateway.annotations | default dict) "external-dns.alpha.kubernetes.io/hostname" | default "" }}
   {{- $coordExternalPortBase = int .Values.externalAccessConfig.gateway.coordinatorPortBase }}
 {{- end }}
+{{/*
+  LoadBalancer = one dedicated LB Service per instance, so the external-dns
+  hostname is per instance, not per tier — it is read inside the registration
+  loops below from the instance's externalAccessAnnotations merged with the
+  tier annotations (per-instance wins, mirroring services-*-external.yaml).
+  An instance without a hostname annotation keeps the internal bolt_server.
+*/}}
+{{- $dataPerInstanceLB := eq .Values.externalAccessConfig.dataInstance.serviceType "LoadBalancer" }}
+{{- $coordPerInstanceLB := eq .Values.externalAccessConfig.coordinator.serviceType "LoadBalancer" }}
 
 apiVersion: batch/v1
 kind: Job
@@ -340,13 +354,18 @@ spec:
               {{- else }}
               {{- $coordBoltServer = printf "%s:%d" $coordExternalHost (add $coordExternalPortBase (int .id)) }}
               {{- end }}
+              {{- else if $coordPerInstanceLB }}
+              {{- $coordLBAnnotations := mergeOverwrite (dict) ($.Values.externalAccessConfig.coordinator.annotations | default dict) (.externalAccessAnnotations | default dict) }}
+              {{- with index $coordLBAnnotations "external-dns.alpha.kubernetes.io/hostname" }}
+              {{- $coordBoltServer = printf "%s:%v" . $.Values.ports.boltPort }}
+              {{- end }}
               {{- end }}
               run_ddl_with_retries "ADD COORDINATOR {{ .id }}" 'ADD COORDINATOR {{ .id }} WITH CONFIG {"bolt_server": "{{ $coordBoltServer }}", "management_server": "memgraph-coordinator-{{ .id }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.ports.managementPort }}", "coordinator_server": "memgraph-coordinator-{{ .id }}.{{$.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.ports.coordinatorPort }}"};'
               # ADD COORDINATOR no-ops if already registered, so reconcile bolt_server
               # separately. $coordBoltServer is the external-dns host:port when
-              # ingress/gateway is enabled, otherwise the internal cluster address, so
-              # this both applies hostname changes and reverts to internal when the
-              # external access is turned off.
+              # ingress/gateway/per-instance LoadBalancer is enabled, otherwise the
+              # internal cluster address, so this both applies hostname changes and
+              # reverts to internal when the external access is turned off.
               reconcile_bolt_server "coordinator_{{ .id }}" "COORDINATOR {{ .id }}" "{{ $coordBoltServer }}"
               {{- end }}
 
@@ -359,13 +378,19 @@ spec:
               {{- else }}
               {{- $dataBoltServer = printf "%s:%d" $dataExternalHost (add $dataExternalPortBase (int $instance.id)) }}
               {{- end }}
+              {{- else if $dataPerInstanceLB }}
+              {{- $dataLBAnnotations := mergeOverwrite (dict) ($.Values.externalAccessConfig.dataInstance.annotations | default dict) ($instance.externalAccessAnnotations | default dict) }}
+              {{- with index $dataLBAnnotations "external-dns.alpha.kubernetes.io/hostname" }}
+              {{- $dataBoltServer = printf "%s:%v" . $.Values.ports.boltPort }}
+              {{- end }}
               {{- end }}
               run_ddl_with_retries "REGISTER INSTANCE instance_{{ add (int $instance.id) 1 }}" 'REGISTER INSTANCE instance_{{ add (int $instance.id) 1 }} WITH CONFIG {"bolt_server": "{{ $dataBoltServer }}", "management_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.ports.managementPort }}", "replication_server": "memgraph-data-{{ $instance.id }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.ports.replicationPort }}"};'
               # REGISTER INSTANCE no-ops if already registered, so reconcile bolt_server
               # separately. $dataBoltServer is the external-dns host:port when
-              # ingress/gateway is enabled, otherwise the internal cluster address, so
-              # this both applies hostname changes and reverts to internal when the
-              # external access is turned off. The instance name is keyed by the data
+              # ingress/gateway/per-instance LoadBalancer is enabled, otherwise the
+              # internal cluster address, so this both applies hostname changes and
+              # reverts to internal when the external access is turned off. The
+              # instance name is keyed by the data
               # instance .id (name = instance_<id+1>), not array position, so removing a
               # middle entry leaves the other instances' names and endpoints untouched.
               # The +1 keeps names identical to the previous index-based scheme for the

--- a/charts/memgraph-high-availability/templates/gateway.yaml
+++ b/charts/memgraph-high-availability/templates/gateway.yaml
@@ -1,6 +1,14 @@
 {{- if .Values.externalAccessConfig.gateway.enabled }}
+{{- include "memgraph.validateExternalAccess" . }}
 {{- $gatewayName := .Values.externalAccessConfig.gateway.existingGatewayName | default (printf "%s-gateway" (include "memgraph.fullname" .)) }}
 {{- $gatewayNamespace := .Values.externalAccessConfig.gateway.existingGatewayNamespace | default .Release.Namespace }}
+{{/*
+  A tier whose serviceType is set gets its external access from that service
+  type instead — the Gateway only exposes tiers with an empty serviceType.
+  Validation above guarantees at least one tier qualifies.
+*/}}
+{{- $gatewayData := eq (.Values.externalAccessConfig.dataInstance.serviceType | default "") "" }}
+{{- $gatewayCoords := eq (.Values.externalAccessConfig.coordinator.serviceType | default "") "" }}
 {{- if not .Values.externalAccessConfig.gateway.existingGatewayName }}
 {{- if not .Values.externalAccessConfig.gateway.gatewayClassName }}
   {{- fail "externalAccessConfig.gateway.gatewayClassName is required when gateway is enabled and existingGatewayName is not set." }}
@@ -21,6 +29,7 @@ metadata:
 spec:
   gatewayClassName: {{ .Values.externalAccessConfig.gateway.gatewayClassName }}
   listeners:
+  {{- if $gatewayData }}
   {{- range $index, $data := .Values.data }}
     - name: data-{{ $data.id }}-bolt
       protocol: TCP
@@ -30,6 +39,8 @@ spec:
           - group: gateway.networking.k8s.io
             kind: TCPRoute
   {{- end }}
+  {{- end }}
+  {{- if $gatewayCoords }}
   {{- range .Values.coordinators }}
     - name: coordinator-{{ .id }}-bolt
       protocol: TCP
@@ -39,7 +50,9 @@ spec:
           - group: gateway.networking.k8s.io
             kind: TCPRoute
   {{- end }}
+  {{- end }}
 {{- end }}
+{{- if $gatewayData }}
 {{- range $index, $data := .Values.data }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
@@ -59,6 +72,8 @@ spec:
         - name: memgraph-data-{{ $data.id }}
           port: {{ $.Values.ports.boltPort }}
 {{- end }}
+{{- end }}
+{{- if $gatewayCoords }}
 {{- range .Values.coordinators }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
@@ -77,5 +92,6 @@ spec:
     - backendRefs:
         - name: memgraph-coordinator-{{ .id }}
           port: {{ $.Values.ports.boltPort }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -99,6 +99,10 @@ externalAccessConfig:
     # controller Service. That Service is one LB with one external-dns hostname, so every
     # IngressNginx instance's external bolt_server uses that shared hostname (instances are told
     # apart by port, not host) — set the same hostname on both tiers.
+    # For serviceType: LoadBalancer, do NOT set an external-dns hostname here: each instance gets
+    # its own LB Service, so a tier-level hostname would put one DNS record in front of every LB
+    # and register the same bolt_server for all instances. Set the hostname per instance in
+    # data[].externalAccessAnnotations instead.
     # Example:
     # annotations:
       # external-dns.alpha.kubernetes.io/hostname: "memgraph.data.example.com"
@@ -111,6 +115,10 @@ externalAccessConfig:
     # For serviceType: CommonLoadBalancer, applied to the single "coordinators" LoadBalancer
     # Service; its external-dns hostname sets every coordinator's external bolt_server as
     # hostname:boltPort (the same shared address for all coordinators).
+    # For serviceType: LoadBalancer, do NOT set an external-dns hostname here: each coordinator
+    # gets its own LB Service, so a tier-level hostname would put one DNS record in front of every
+    # LB and register the same bolt_server for all coordinators. Set the hostname per instance in
+    # coordinators[].externalAccessAnnotations instead.
     # Example:
     # annotations:
       # external-dns.alpha.kubernetes.io/hostname: "memgraph.coordinators.example.com"

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -118,6 +118,10 @@ externalAccessConfig:
     dataPortBase: 9000 # Data instance ports: dataPortBase + data instance id (9000, 9001, ...)
     coordinatorPortBase: 10000 # Coordinator ports: coordinatorPortBase + coordinator id (10001, 10002, ...). Kept well above dataPortBase so the data and coordinator port ranges never overlap.
   gateway:
+    # The Gateway only exposes tiers whose serviceType is empty: a tier with
+    # dataInstance/coordinator.serviceType set is excluded from the Gateway and uses that
+    # service type instead. Enabling the gateway with BOTH serviceTypes set is an error
+    # (the Gateway would apply to nothing).
     enabled: false
     gatewayClassName: "" # Required when creating a new Gateway. Name of a pre-existing GatewayClass (e.g., "eg" for Envoy Gateway)
     existingGatewayName: "" # If set, skip Gateway creation and attach routes to this existing Gateway

--- a/examples/gateway/gc.yaml
+++ b/examples/gateway/gc.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller


### PR DESCRIPTION
Improvements:
- Bolt server will now get automatically set-up through our cluster-setup hook when using LoadBalancer service type both for coordinators and data instance
- Added gc.yaml as an example for GatewayClass
- Gateway will apply to data instances only if dataInstance.serviceType is not defined. Same for coordinators.