### PR TITLE
feat: Single TCP route for all coords

### DIFF
--- a/charts/memgraph-high-availability/templates/NOTES.txt
+++ b/charts/memgraph-high-availability/templates/NOTES.txt
@@ -12,4 +12,15 @@ You can find information about installing this chart on Memgraph docs https://me
 {{- if .Values.externalAccessConfig.gateway.enabled }}
 
 Gateway API external access is enabled.
+{{- if eq (.Values.externalAccessConfig.dataInstance.serviceType | default "") "" }}
+  Data instances: one listener per instance on port dataPortBase + id:
+  {{- range .Values.data }}
+    - data {{ .id }}: {{ add (int $.Values.externalAccessConfig.gateway.dataPortBase) (int .id) }}
+  {{- end }}
+{{- end }}
+{{- if eq (.Values.externalAccessConfig.coordinator.serviceType | default "") "" }}
+  Coordinators: a single listener on the Bolt port ({{ .Values.ports.boltPort }}) with one TCPRoute
+  fanning out to all {{ len .Values.coordinators }} coordinators, so connections are load balanced
+  (round-robin) across them. Point your client at that one port.
+{{- end }}
 {{- end }}

--- a/charts/memgraph-high-availability/templates/_helpers.tpl
+++ b/charts/memgraph-high-availability/templates/_helpers.tpl
@@ -41,10 +41,25 @@ cluster-setup hook runs.
 */}}
 {{- define "memgraph.validateExternalAccess" -}}
 {{- if .Values.externalAccessConfig.gateway.enabled -}}
+{{- if or (hasKey .Values.externalAccessConfig.gateway "coordinatorPortBase") (hasKey .Values.externalAccessConfig.gateway "coordinatorPort") -}}
+{{- fail "externalAccessConfig.gateway.coordinatorPortBase/coordinatorPort no longer exist: all coordinators now share one Gateway listener/TCPRoute on ports.boltPort, so connections are load balanced across them instead of one port per coordinator. Remove the value; change ports.boltPort if you need a different port." -}}
+{{- end -}}
 {{- $dataHasServiceType := ne (.Values.externalAccessConfig.dataInstance.serviceType | default "") "" -}}
 {{- $coordHasServiceType := ne (.Values.externalAccessConfig.coordinator.serviceType | default "") "" -}}
 {{- if and $dataHasServiceType $coordHasServiceType -}}
 {{- fail "externalAccessConfig.gateway.enabled requires at least one tier without a serviceType: a tier with dataInstance/coordinator.serviceType set is excluded from the Gateway, so with both set the Gateway would apply to nothing. Unset one serviceType or disable the gateway." -}}
+{{- end -}}
+{{- /*
+  Both tiers on the Gateway: the coordinators' shared listener sits on
+  ports.boltPort, so no data listener (dataPortBase + id) may land on it — two
+  TCP listeners on one port conflict and the Gateway rejects them.
+*/ -}}
+{{- if and (not $dataHasServiceType) (not $coordHasServiceType) -}}
+{{- range .Values.data -}}
+{{- if eq (add (int $.Values.externalAccessConfig.gateway.dataPortBase) (int .id)) (int $.Values.ports.boltPort) -}}
+{{- fail (printf "Gateway port conflict: data instance %v maps to port %d (dataPortBase + id), which is ports.boltPort — the port of the shared coordinators listener. Move externalAccessConfig.gateway.dataPortBase away from ports.boltPort." .id (int $.Values.ports.boltPort)) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/memgraph-high-availability/templates/cluster-setup.yaml
+++ b/charts/memgraph-high-availability/templates/cluster-setup.yaml
@@ -5,20 +5,22 @@
 {{/*
   When a tier is exposed through ingress-nginx or gateway with an external-dns
   hostname, its instances are reachable on that hostname at a per-instance port
-  (dataPortBase + id / coordinatorPortBase + id), so the routing "bolt_server"
-  registered with the coordinators must point to that external hostname:port.
-  The management/coordinator/replication servers stay internal (intra-cluster).
+  (dataPortBase + id / ingress coordinatorPortBase + id) or, for gateway
+  coordinators, at one shared port (the bolt port), so the routing "bolt_server"
+  registered with the coordinators must point to that external hostname:port. The
+  management/coordinator/replication servers stay internal (intra-cluster).
 
   This is resolved PER TIER: data instances use the dataInstance tier's own
   service type + external-dns hostname, and coordinators use the coordinator
   tier's own — the two can differ (e.g. data via IngressNginx, coordinators via
-  CommonLoadBalancer). Only IngressNginx/gateway give each instance a unique
-  external port; CommonLoadBalancer shares one hostname:boltPort across all
-  coordinators; LoadBalancer gives each instance its own LB Service, so its
-  hostname is resolved PER INSTANCE from the instance's
-  externalAccessAnnotations (merged with the tier annotations, per-instance
-  winning — the same merge the external service templates apply) at the shared
-  bolt port. NodePort keeps the internal bolt_server.
+  CommonLoadBalancer). IngressNginx (both tiers) and gateway data instances get
+  a unique external port per instance; CommonLoadBalancer and gateway
+  coordinators share one hostname:port across all coordinators (one LB /
+  Gateway listener round-robining over them); LoadBalancer gives each instance
+  its own LB Service, so its hostname is resolved PER INSTANCE from the
+  instance's externalAccessAnnotations (merged with the tier annotations,
+  per-instance winning — the same merge the external service templates apply)
+  at the shared bolt port. NodePort keeps the internal bolt_server.
 
   The gateway only applies to a tier whose serviceType is EMPTY — a tier with a
   serviceType set gets its external access from that service type instead
@@ -26,11 +28,12 @@
   serviceType, since the Gateway would then apply to nothing).
 */}}
 {{/*
-  Per instance the external port is either unique (IngressNginx / gateway give
-  portBase + id) or a single shared port (CommonLoadBalancer puts every
-  coordinator behind one bolt port; a per-instance LoadBalancer exposes its
-  instance on the bolt port too). $*ExternalPort, when > 0, is that shared
-  fixed port and takes precedence over $*ExternalPortBase + id in the loops below.
+  Per instance the external port is either unique (IngressNginx and gateway data
+  instances give portBase + id) or a single shared port (CommonLoadBalancer and
+  gateway coordinators put every coordinator behind one port; a per-instance
+  LoadBalancer exposes its instance on the bolt port too). $*ExternalPort, when
+  > 0, is that shared fixed port and takes precedence over $*ExternalPortBase +
+  id in the loops below.
 */}}
 {{- $dataExternalHost := "" }}
 {{- $dataExternalPortBase := 0 }}
@@ -63,8 +66,11 @@
   {{- $coordExternalHost = index (.Values.externalAccessConfig.coordinator.annotations | default dict) "external-dns.alpha.kubernetes.io/hostname" | default "" }}
   {{- $coordExternalPort = int .Values.ports.boltPort }}
 {{- else if and .Values.externalAccessConfig.gateway.enabled (eq .Values.externalAccessConfig.coordinator.serviceType "") }}
+  {{- /* All coordinators sit behind ONE Gateway listener / TCPRoute on the bolt
+         port (round-robin across the coordinator Services), so they share a
+         single external host:boltPort — same shape as CommonLoadBalancer. */}}
   {{- $coordExternalHost = index (.Values.externalAccessConfig.gateway.annotations | default dict) "external-dns.alpha.kubernetes.io/hostname" | default "" }}
-  {{- $coordExternalPortBase = int .Values.externalAccessConfig.gateway.coordinatorPortBase }}
+  {{- $coordExternalPort = int .Values.ports.boltPort }}
 {{- end }}
 {{/*
   LoadBalancer = one dedicated LB Service per instance, so the external-dns

--- a/charts/memgraph-high-availability/templates/gateway.yaml
+++ b/charts/memgraph-high-availability/templates/gateway.yaml
@@ -41,15 +41,21 @@ spec:
   {{- end }}
   {{- end }}
   {{- if $gatewayCoords }}
-  {{- range .Values.coordinators }}
-    - name: coordinator-{{ .id }}-bolt
+  {{- /*
+    One shared listener for ALL coordinators (not one per coordinator), on the
+    Bolt port: the single TCPRoute below lists every coordinator Service as a
+    backendRef, so the Gateway round-robins new connections across them. A
+    client only needs one address — host:boltPort, the same port it would use
+    in-cluster — and it keeps working when the coordinator it happened to land
+    on goes away.
+  */}}
+    - name: coordinators-bolt
       protocol: TCP
-      port: {{ add (int $.Values.externalAccessConfig.gateway.coordinatorPortBase) (int .id) }}
+      port: {{ .Values.ports.boltPort }}
       allowedRoutes:
         kinds:
           - group: gateway.networking.k8s.io
             kind: TCPRoute
-  {{- end }}
   {{- end }}
 {{- end }}
 {{- if $gatewayData }}
@@ -78,28 +84,34 @@ spec:
 {{- end }}
 {{- end }}
 {{- if $gatewayCoords }}
-{{- range .Values.coordinators }}
 ---
+{{- /*
+  A single TCPRoute for all coordinators. Multiple backendRefs with equal
+  (default) weight make the Gateway distribute connections round-robin over the
+  coordinator Services, so clients get one stable entrypoint into the cluster
+  instead of one address per coordinator.
+*/}}
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: {{ include "memgraph.fullname" $ }}-coordinator-{{ .id }}-bolt
-  {{- with $.Values.externalAccessConfig.gateway.annotations }}
+  name: {{ include "memgraph.fullname" . }}-coordinators-bolt
+  {{- with .Values.externalAccessConfig.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "memgraph.labels" $ | nindent 4 }}
-    app: memgraph-coordinator-{{ .id }}
+    {{- include "memgraph.labels" . | nindent 4 }}
+    app: memgraph-coordinators
 spec:
   parentRefs:
     - name: {{ $gatewayName }}
       namespace: {{ $gatewayNamespace }}
-      sectionName: coordinator-{{ .id }}-bolt
+      sectionName: coordinators-bolt
   rules:
     - backendRefs:
+      {{- range .Values.coordinators }}
         - name: memgraph-coordinator-{{ .id }}
           port: {{ $.Values.ports.boltPort }}
-{{- end }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -136,8 +136,12 @@ externalAccessConfig:
     existingGatewayNamespace: "" # Namespace of the existing Gateway. Defaults to release namespace if empty
     annotations: {}
     labels: {}
-    dataPortBase: 9000 # Data instance ports: dataPortBase + data instance id (9000, 9001, ...)
-    coordinatorPortBase: 10000 # Coordinator ports: coordinatorPortBase + coordinator id (10001, 10002, ...). Kept well above dataPortBase so the data and coordinator port ranges never overlap.
+    dataPortBase: 9000 # Data instance ports: dataPortBase + data instance id (9000, 9001, ...). Each data instance needs its own port because clients must reach a specific instance.
+    # Coordinators share ONE listener, on ports.boltPort (7687): a single TCPRoute
+    # fans out to every coordinator Service, so the Gateway load-balances
+    # (round-robin) across them and every coordinator's external bolt_server is
+    # that same host:boltPort. Keep dataPortBase away from ports.boltPort so the
+    # data and coordinator listener ports never collide.
 
 headlessService:
   enabled: false # If set to true, each data and coordinator instance will use headless service

--- a/examples/gateway/gateway.yaml
+++ b/examples/gateway/gateway.yaml
@@ -55,23 +55,14 @@ spec:
         kinds:
           - group: gateway.networking.k8s.io
             kind: TCPRoute
-    # HA coordinator listeners (one per coordinator)
-    - name: coordinator-1-bolt
-      port: 9011
-      protocol: TCP
-      allowedRoutes:
-        kinds:
-          - group: gateway.networking.k8s.io
-            kind: TCPRoute
-    - name: coordinator-2-bolt
-      port: 9012
-      protocol: TCP
-      allowedRoutes:
-        kinds:
-          - group: gateway.networking.k8s.io
-            kind: TCPRoute
-    - name: coordinator-3-bolt
-      port: 9013
+    # HA coordinator listener — ONE shared listener for all coordinators. The
+    # chart creates a single TCPRoute ("coordinators-bolt" sectionName) whose
+    # backendRefs list every coordinator, so the Gateway load balances
+    # (round-robin) across them and scaling the coordinator tier needs no new
+    # listener. The name must be "coordinators-bolt" and the port must match
+    # ports.boltPort (default 7687).
+    - name: coordinators-bolt
+      port: 7687
       protocol: TCP
       allowedRoutes:
         kinds:

--- a/examples/gateway/traefik-values.yaml
+++ b/examples/gateway/traefik-values.yaml
@@ -33,8 +33,9 @@ providers:
         # external-dns.alpha.kubernetes.io/hostname annotation on the Gateway.
         enabled: true
 
-# The Memgraph charts create their own Gateway (one listener per data instance
-# and coordinator), so the chart's default Gateway is not needed.
+# The Memgraph charts create their own Gateway (one listener per data instance,
+# plus one shared listener for all coordinators), so the chart's default Gateway
+# is not needed.
 gateway:
   enabled: false
 
@@ -61,24 +62,13 @@ ports:
     expose:
       default: true
 
-  # Commented out because the recommended approach is to use CommonLoadBalancer for coordinators
-  # Coordinators: externalAccessConfig.gateway.coordinatorPortBase + coordinator id.
-  # Defaults are coordinatorPortBase 10000 with coordinator ids 1, 2 and 3.
-  # coord-1:
-  #   port: 10001
-  #   exposedPort: 10001
-  #   protocol: TCP
-  #   expose:
-  #     default: true
-  # coord-2:
-  #   port: 10002
-  #   exposedPort: 10002
-  #   protocol: TCP
-  #   expose:
-  #     default: true
-  # coord-3:
-  #   port: 10003
-  #   exposedPort: 10003
+  # Commented out because the recommended approach is to use CommonLoadBalancer for coordinators.
+  # Coordinators share ONE listener on ports.boltPort (default 7687) — a single
+  # TCPRoute round-robins over all coordinators, so one entryPoint covers the whole
+  # coordinator tier no matter how many there are.
+  # coordinators:
+  #   port: 7687
+  #   exposedPort: 7687
   #   protocol: TCP
   #   expose:
   #     default: true
@@ -94,5 +84,6 @@ ports:
   #   expose:
   #     default: true
 
-# Add more entryPoints whenever you scale the cluster: a new data instance with
-# id 2 needs port 9002, a fourth coordinator needs 10004, and so on.
+# Add more entryPoints whenever you scale the data tier: a new data instance with
+# id 2 needs port 9002, and so on. Adding coordinators needs no new entryPoint —
+# they all share the single coordinator port.


### PR DESCRIPTION
Creates one TCP route for all coordinators instead of one each.