### PR TITLE
feat: update default log level to INFO

### DIFF
--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -448,13 +448,13 @@ initContainers:
 commonArgs:
   data: # Common args for data instances
     logging:
-      log_level: "TRACE" # Must not be empty.
+      log_level: "INFO" # Must not be empty.
       also_log_to_stderr: true # Can only be bool
       log_file: "/var/log/memgraph/memgraph.log" # If empty, log file won't be created
       log_retention_days: 35 # For how many days should logs get persisted
   coordinators: # Common args for coordinator instances
     logging:
-      log_level: "TRACE" # Must not be empty.
+      log_level: "INFO" # Must not be empty.
       also_log_to_stderr: true # Can only be bool
       log_file: "/var/log/memgraph/memgraph.log" # If empty, log file won't be created
       log_retention_days: 35

--- a/charts/memgraph/README.md
+++ b/charts/memgraph/README.md
@@ -146,7 +146,7 @@ The `memgraphConfig` parameter should be a list of strings defining the values o
 ```yaml
 memgraphConfig:
   - "--also-log-to-stderr=true"
-  - "--log-level=TRACE"
+  - "--log-level=INFO"
   - "--log-file=''"
 
 ```


### PR DESCRIPTION
## Summary
- set Memgraph HA data and coordinator default log levels to INFO
- update the standalone chart configuration example to use INFO

## Validation
- `helm lint charts/memgraph-high-availability`
- rendered the HA chart and confirmed `--log-level=INFO` is emitted