### PR TITLE
feat: Add per-instance HA volumes

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -305,6 +305,9 @@ spec:
           {{- with $.Values.storage.coordinators.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- with $coordinator.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -358,6 +361,9 @@ spec:
       {{- end }}
       {{- if $.Values.storage.coordinators.extraVolumes }}
       {{- tpl (toYaml $.Values.storage.coordinators.extraVolumes) $ | nindent 6 }}
+      {{- end }}
+      {{- if $coordinator.extraVolumes }}
+      {{- tpl (toYaml $coordinator.extraVolumes) $ | nindent 6 }}
       {{- end }}
 
   volumeClaimTemplates:

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -301,6 +301,9 @@ spec:
           {{- with $.Values.storage.data.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- with $data.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -354,6 +357,9 @@ spec:
       {{- end }}
       {{- if $.Values.storage.data.extraVolumes }}
       {{- tpl (toYaml $.Values.storage.data.extraVolumes) $ | nindent 6 }}
+      {{- end }}
+      {{- if $data.extraVolumes }}
+      {{- tpl (toYaml $data.extraVolumes) $ | nindent 6 }}
       {{- end }}
 
   volumeClaimTemplates:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -476,6 +476,10 @@ data:
     volumeSnapshotName: data-0-snap # Used only if restoreDataFromSnapshot is set to true
     internalAccessAnnotations: {} # Per-instance annotations for internal ClusterIP service
     externalAccessAnnotations: {} # Per-instance annotations for external access service (merged with externalAccessConfig.dataInstance.annotations, per-instance takes precedence)
+    # Optional volumes mounted only by this data instance. Supports Helm templating (e.g. {{ .Release.Name }}).
+    extraVolumes: []
+    # Optional mounts for this data instance. Names must match extraVolumes entries.
+    extraVolumeMounts: []
     tls:
       bolt:
         enabled: false
@@ -502,6 +506,8 @@ data:
     volumeSnapshotName: data-1-snap
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
+    extraVolumes: []
+    extraVolumeMounts: []
     tls:
       bolt:
         enabled: false
@@ -523,6 +529,10 @@ coordinators:
     volumeSnapshotName: coord-1-snap
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
+    # Optional volumes mounted only by this coordinator. Supports Helm templating (e.g. {{ .Release.Name }}).
+    extraVolumes: []
+    # Optional mounts for this coordinator. Names must match extraVolumes entries.
+    extraVolumeMounts: []
     tls:
       bolt:
         enabled: false
@@ -542,6 +552,8 @@ coordinators:
     volumeSnapshotName: coord-2-snap
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
+    extraVolumes: []
+    extraVolumeMounts: []
     tls:
       bolt:
         enabled: false
@@ -561,6 +573,8 @@ coordinators:
     volumeSnapshotName: coord-3-snap
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
+    extraVolumes: []
+    extraVolumeMounts: []
     tls:
       bolt:
         enabled: false

--- a/examples/pvc_import.yaml
+++ b/examples/pvc_import.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-csv-import
+  namespace: memgraph
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary
- add data-instance-specific extra volumes and mounts
- add coordinator-instance-specific extra volumes and mounts
- retain shared data and coordinator volume settings

## Testing
- helm template test-release charts/memgraph-high-availability
- pre-commit run --files charts/memgraph-high-availability/templates/data.yaml charts/memgraph-high-availability/templates/coordinators.yaml charts/memgraph-high-availability/values.yaml