### PR TITLE
feat: Add configurable topology key to HA chart

### DIFF
--- a/charts/memgraph-high-availability/templates/coordinators.yaml
+++ b/charts/memgraph-high-availability/templates/coordinators.yaml
@@ -63,7 +63,7 @@ spec:
                 operator: In
                 values:
                 - coordinator
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- else if $.Values.affinity.unique }}
         # Unique Affinity: Schedule pods on different nodes
         podAntiAffinity:
@@ -75,7 +75,7 @@ spec:
                 values:
                 - coordinator
                 - data
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- else if $.Values.affinity.parity }}
         # Parity Affinity: One coordinator and one data node per node, coordinator schedules first, needs to be in pairs
         podAntiAffinity:
@@ -86,7 +86,7 @@ spec:
                 operator: In
                 values:
                 - coordinator
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- else }}
         # Default Affinity: Avoid scheduling on the same node
         podAntiAffinity:
@@ -99,7 +99,7 @@ spec:
                       operator: In
                       values:
                         - coordinator
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- end }}
       initContainers:
       {{- if $.Values.sysctlInitContainer.enabled }}

--- a/charts/memgraph-high-availability/templates/data.yaml
+++ b/charts/memgraph-high-availability/templates/data.yaml
@@ -62,7 +62,7 @@ spec:
                 operator: In
                 values:
                 - data
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- else if $.Values.affinity.unique }}
         # Unique Affinity: Schedule pods on different nodes where there is no coordinator or data pod
         podAntiAffinity:
@@ -74,7 +74,7 @@ spec:
                 values:
                 - coordinator
                 - data
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- else if $.Values.affinity.parity }}
         # Parity Affinity: One coordinator and one data node per node, coordinator schedules first, needs to be in pairs
         podAffinity:
@@ -85,7 +85,7 @@ spec:
                     operator: In
                     values:
                       - coordinator
-              topologyKey: "kubernetes.io/hostname"
+              topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -94,7 +94,7 @@ spec:
                 operator: In
                 values:
                 - data
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- else }}
         # Default Affinity: Avoid scheduling on the same node
         podAntiAffinity:
@@ -107,7 +107,7 @@ spec:
                       operator: In
                       values:
                         - data
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ $.Values.affinity.topologyKey | quote }}
         {{- end }}
 
       initContainers:

--- a/charts/memgraph-high-availability/values.yaml
+++ b/charts/memgraph-high-availability/values.yaml
@@ -162,6 +162,8 @@ headlessService:
 # and coordinator pods will avoid being scheduled on the same node as other coordinator pods.
 # Deployment won't fail if there is no sufficient nodes.
 affinity:
+  # The topology domain used by pod affinity and anti-affinity rules.
+  topologyKey: "kubernetes.io/hostname"
   # The unique affinity, will schedule the pods on different nodes in the cluster.
   # This means coordinators and data nodes will not be scheduled on the same node. If there are more pods than nodes, deployment will fail.
   unique: false


### PR DESCRIPTION
Adds `affinity.topologyKey` support to the Memgraph high-availability chart and applies it to all coordinator and data pod affinity rules.

The default remains `kubernetes.io/hostname`, preserving the chart’s current scheduling behavior.

Validation:
- `helm lint charts/memgraph-high-availability`
- Rendered all affinity modes with the default and a custom topology key
- Confirmed the default rendered manifests are unchanged