### PR TITLE
Add memgraph-prometheus-exporter Helm chart

### DIFF
--- a/.github/workflows/lint-test-prometheus-exporter.yaml
+++ b/.github/workflows/lint-test-prometheus-exporter.yaml
@@ -1,0 +1,56 @@
+name: Lint and Test Charts Memgraph Prometheus Exporter
+
+on:
+  pull_request:
+    paths:
+      - 'charts/memgraph-prometheus-exporter/**'
+
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.14.0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false --charts charts/memgraph-prometheus-exporter --lint-conf lintconf.yaml
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.8.0
+
+      - name: Create exporter config Secret (existing-secret ci case)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          kubectl create secret generic memgraph-adr-exporter-config \
+            --namespace default \
+            --from-literal=ha_config.yaml=$'exporter:\n  port: 9115\n  pull_frequency_seconds: 5\ninstances: []\n'
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --charts charts/memgraph-prometheus-exporter --namespace default

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: end-of-file-fixer
   - id: check-json
   - id: check-yaml
-    exclude: ^charts/(memgraph|memgraph-lab|memgraph-high-availability|memgraph-mcp)/templates/
+    exclude: ^charts/(memgraph|memgraph-lab|memgraph-high-availability|memgraph-mcp|memgraph-prometheus-exporter)/templates/
   - id: mixed-line-ending
   - id: check-merge-conflict
   - id: detect-private-key

--- a/charts/memgraph-prometheus-exporter/.helmignore
+++ b/charts/memgraph-prometheus-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/memgraph-prometheus-exporter/Chart.yaml
+++ b/charts/memgraph-prometheus-exporter/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: memgraph-prometheus-exporter
+description: Standalone Prometheus exporter for a Memgraph High-Availability cluster (memgraph/prometheus-exporter). Polls each node's :9091 JSON metrics endpoint and exposes aggregated + HA cluster-state metrics.
+type: application
+version: 0.1.0
+appVersion: "0.2.3"
+home: https://memgraph.com/
+icon: https://public-assets.memgraph.com/memgraph-logo/logo-large.png
+sources:
+  - https://github.com/memgraph/prometheus-exporter
+  - https://github.com/memgraph/helm-charts
+maintainers:
+  - name: Memgraph
+    email: tech@memgraph.com
+keywords:
+  - memgraph
+  - prometheus
+  - exporter
+  - high-availability

--- a/charts/memgraph-prometheus-exporter/README.md
+++ b/charts/memgraph-prometheus-exporter/README.md
@@ -1,0 +1,34 @@
+# memgraph-prometheus-exporter
+
+Standalone Helm chart for the [Memgraph HA Prometheus exporter](https://github.com/memgraph/prometheus-exporter). It deploys the exporter (a `Deployment` + `Service` + optional `ServiceMonitor`); the exporter polls each Memgraph node's `:9091` JSON metrics endpoint and exposes aggregated + HA cluster-state metrics (main/replica roles, coordinator leadership) on `exporter.port` (default `9115`). Memgraph must serve JSON on `:9091` (its default) — not OpenMetrics — or the exporter cannot parse the response.
+
+Use this when Memgraph runs **outside** Kubernetes (e.g. on EC2) and you only want the exporter in-cluster — the full `memgraph-high-availability` chart bundles the exporter with Memgraph itself.
+
+## Instance list — three interchangeable sources
+
+The exporter needs an explicit per-node list. This chart can build it three ways (precedence top to bottom):
+
+| Source | `values` | External dependency |
+|---|---|---|
+| Existing Secret | `hosts.existingSecret.name` | a `Secret` holding a ready `ha_config.yaml` (e.g. synced from a secrets manager) |
+| Explicit list | `hosts.instances[]` | none |
+| Templated (default) | `hosts.cluster.*` | none |
+
+Templated mode derives every node URL from the deterministic naming `‹namePrefix›-{coordinator,data}-‹startIndex+i›.‹domain›`. Every string field is rendered with `tpl`, so values may contain Helm expressions:
+
+```yaml
+hosts:
+  cluster:
+    namePrefix: '{{ .Values.global.env }}-memgraph-adr'
+    domain: '{{ .Values.global.internalDomainSuffix }}'
+    coordinatorCount: 3
+    dataCount: 3
+```
+
+## Notes
+- The exporter reads its config once at startup; the Deployment carries a `checksum/ha-config` annotation so it rolls when the templated/explicit list changes. For the Secret source, set `reloaderEnabled: true` (requires Stakater Reloader) so it rolls on Secret change.
+- `global.imageRegistry` overrides `image.registry` (point at a private mirror without editing the chart).
+- `serviceMonitor.enabled` is `false` by default (it needs the Prometheus Operator CRDs); set it `true` where the operator is installed.
+- **Cluster mode** requires `hosts.cluster.namePrefix` and `hosts.cluster.domain` to be set (otherwise the rendered URLs are incomplete).
+- **Instances mode**: each entry needs `name`, `url` (host only — no `:port`), `port`, and `type` (`coordinator` or `data_instance`); add `skipTlsVerify: true` for an `https` node.
+- **existingSecret mode**: the Secret's `ha_config.yaml` is used verbatim — its `exporter.port` must match `.Values.exporter.port` (the Service/probe port), and instance `type`s must be `coordinator`/`data_instance` or the exporter exits.

--- a/charts/memgraph-prometheus-exporter/ci/existing-secret-values.yaml
+++ b/charts/memgraph-prometheus-exporter/ci/existing-secret-values.yaml
@@ -1,0 +1,9 @@
+# ct lint case: config from an existing Secret (e.g. synced from a secrets manager)
+hosts:
+  cluster:
+    enabled: false
+  existingSecret:
+    name: memgraph-adr-exporter-config
+    key: ha_config.yaml
+serviceMonitor:
+  enabled: false

--- a/charts/memgraph-prometheus-exporter/ci/templated-values.yaml
+++ b/charts/memgraph-prometheus-exporter/ci/templated-values.yaml
@@ -1,0 +1,10 @@
+# ct lint case: templated instance list (no external dependency)
+hosts:
+  cluster:
+    enabled: true
+    namePrefix: stg-us-west-2-memgraph-adr
+    domain: stg.internal.bigpanda.io
+    coordinatorCount: 3
+    dataCount: 3
+serviceMonitor:
+  enabled: false

--- a/charts/memgraph-prometheus-exporter/templates/NOTES.txt
+++ b/charts/memgraph-prometheus-exporter/templates/NOTES.txt
@@ -1,0 +1,18 @@
+memgraph-prometheus-exporter deployed as {{ include "memgraph-prometheus-exporter.fullname" . }}.
+
+Exporter metrics: http://{{ include "memgraph-prometheus-exporter.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.exporter.port }}/
+
+Instance source:
+{{- if .Values.hosts.existingSecret.name }}
+  existingSecret "{{ .Values.hosts.existingSecret.name }}" (key: {{ .Values.hosts.existingSecret.key }})
+{{- else if .Values.hosts.instances }}
+  explicit list ({{ len .Values.hosts.instances }} instances)
+{{- else if .Values.hosts.cluster.enabled }}
+  templated from naming convention ({{ .Values.hosts.cluster.coordinatorCount }} coordinators + {{ .Values.hosts.cluster.dataCount }} data)
+{{- end }}
+
+{{- if .Values.serviceMonitor.enabled }}
+A ServiceMonitor was created; Prometheus will discover this exporter automatically.
+{{- else }}
+ServiceMonitor is disabled — add a scrape config pointing at the Service above.
+{{- end }}

--- a/charts/memgraph-prometheus-exporter/templates/_helpers.tpl
+++ b/charts/memgraph-prometheus-exporter/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{- define "memgraph-prometheus-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "memgraph-prometheus-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "memgraph-prometheus-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "memgraph-prometheus-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "memgraph-prometheus-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "memgraph-prometheus-exporter.labels" -}}
+helm.sh/chart: {{ include "memgraph-prometheus-exporter.chart" . }}
+{{ include "memgraph-prometheus-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/part-of: memgraph
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "memgraph-prometheus-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "memgraph-prometheus-exporter.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/memgraph-prometheus-exporter/templates/deployment.yaml
+++ b/charts/memgraph-prometheus-exporter/templates/deployment.yaml
@@ -1,0 +1,94 @@
+{{- $g := .Values.global | default dict -}}
+{{- $reg := $g.imageRegistry | default .Values.image.registry -}}
+{{- $pullSecrets := $g.imagePullSecrets | default .Values.imagePullSecrets -}}
+{{- $useSecret := .Values.hosts.existingSecret.name -}}
+{{- $configKey := ternary "ha_config.yaml" .Values.hosts.existingSecret.key (empty $useSecret) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "memgraph-prometheus-exporter.fullname" . }}
+  labels: {{- include "memgraph-prometheus-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "memgraph-prometheus-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # exporter reads config once; roll on change (subPath mounts don't refresh)
+        checksum/ha-config: {{ printf "%s-%s" (toJson .Values.hosts) (toJson .Values.exporter) | sha256sum }}
+        {{- if and .Values.reloaderEnabled .Values.hosts.existingSecret.name }}
+        reloader.stakater.com/auto: "true"
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "memgraph-prometheus-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "memgraph-prometheus-exporter.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with $pullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: exporter
+          image: "{{ $reg }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DEPLOYMENT_TYPE
+              value: HA
+            - name: CONFIG_FILE
+              value: /etc/mg-exporter/ha_config.yaml
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.exporter.port }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mg-exporter/ha_config.yaml
+              subPath: {{ $configKey }}
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          {{- with .Values.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          {{- if $useSecret }}
+          secret:
+            secretName: {{ .Values.hosts.existingSecret.name }}
+          {{- else }}
+          configMap:
+            name: {{ include "memgraph-prometheus-exporter.fullname" . }}-config
+          {{- end }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 16Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/memgraph-prometheus-exporter/templates/ha-config.yaml
+++ b/charts/memgraph-prometheus-exporter/templates/ha-config.yaml
@@ -1,0 +1,53 @@
+{{- /* ha_config.yaml ConfigMap. Skipped when hosts.existingSecret.name is set. Source: instances > cluster. */ -}}
+{{- if not .Values.hosts.existingSecret.name }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "memgraph-prometheus-exporter.fullname" . }}-config
+  labels: {{- include "memgraph-prometheus-exporter.labels" . | nindent 4 }}
+data:
+  ha_config.yaml: |
+    exporter:
+      port: {{ .Values.exporter.port }}
+      pull_frequency_seconds: {{ .Values.exporter.pullFrequencySeconds }}
+    instances:
+    {{- if .Values.hosts.instances }}
+      {{- range .Values.hosts.instances }}
+      - name: {{ tpl (.name | toString) $ | quote }}
+        url: {{ tpl (.url | toString) $ | quote }}
+        port: {{ .port | default $.Values.hosts.cluster.metricsPort }}
+        type: {{ .type }}
+        {{- if hasKey . "skipTlsVerify" }}
+        skip_tls_verify: {{ .skipTlsVerify }}
+        {{- end }}
+      {{- end }}
+    {{- else if .Values.hosts.cluster.enabled }}
+      {{- $c := .Values.hosts.cluster }}
+      {{- $prefix := tpl ($c.namePrefix | toString) $ }}
+      {{- $domain := tpl ($c.domain | toString) $ }}
+      {{- $start := int $c.startIndex }}
+      {{- $https := eq ($c.scheme | toString) "https" }}
+      {{- range $i := until (int $c.coordinatorCount) }}
+      {{- $n := add $start $i }}
+      - name: coordinator-{{ $n }}
+        url: {{ printf "%s://%s-coordinator-%d.%s" $c.scheme $prefix $n $domain | quote }}
+        port: {{ $c.metricsPort }}
+        type: coordinator
+        {{- if $https }}
+        skip_tls_verify: {{ $c.skipTlsVerify }}
+        {{- end }}
+      {{- end }}
+      {{- range $i := until (int $c.dataCount) }}
+      {{- $n := add $start $i }}
+      - name: data-{{ $n }}
+        url: {{ printf "%s://%s-data-%d.%s" $c.scheme $prefix $n $domain | quote }}
+        port: {{ $c.metricsPort }}
+        type: data_instance
+        {{- if $https }}
+        skip_tls_verify: {{ $c.skipTlsVerify }}
+        {{- end }}
+      {{- end }}
+    {{- else }}
+      {{- fail "memgraph-prometheus-exporter: set hosts.existingSecret.name, hosts.instances, or hosts.cluster.enabled" }}
+    {{- end }}
+{{- end }}

--- a/charts/memgraph-prometheus-exporter/templates/service.yaml
+++ b/charts/memgraph-prometheus-exporter/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "memgraph-prometheus-exporter.fullname" . }}
+  labels:
+    {{- include "memgraph-prometheus-exporter.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{- include "memgraph-prometheus-exporter.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.exporter.port }}
+      targetPort: metrics
+      protocol: TCP

--- a/charts/memgraph-prometheus-exporter/templates/serviceaccount.yaml
+++ b/charts/memgraph-prometheus-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "memgraph-prometheus-exporter.serviceAccountName" . }}
+  labels: {{- include "memgraph-prometheus-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/memgraph-prometheus-exporter/templates/servicemonitor.yaml
+++ b/charts/memgraph-prometheus-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "memgraph-prometheus-exporter.fullname" . }}
+  labels:
+    {{- include "memgraph-prometheus-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "memgraph-prometheus-exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.serviceMonitor.targetLabels }}
+  targetLabels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/memgraph-prometheus-exporter/values.yaml
+++ b/charts/memgraph-prometheus-exporter/values.yaml
@@ -1,0 +1,97 @@
+# Memgraph HA Prometheus exporter — Deployment + Service + optional ServiceMonitor.
+
+nameOverride: ""
+fullnameOverride: ""
+replicaCount: 1
+
+image:
+  # global.imageRegistry (if set) overrides image.registry.
+  registry: docker.io
+  repository: memgraph/prometheus-exporter
+  tag: ""              # defaults to .Chart.AppVersion
+  pullPolicy: IfNotPresent
+imagePullSecrets: []  # list of {name: <secret>} objects, e.g. [{name: my-registry-creds}]
+
+exporter:
+  port: 9115
+  pullFrequencySeconds: 5
+
+# Instance list. Precedence: existingSecret > instances > cluster. Modes 2 and 3 need no secret store.
+hosts:
+  # 3) Templated from the tofu-memgraph naming (<namePrefix>-{coordinator,data}-<startIndex+i>.<domain>). Fields are tpl-rendered.
+  cluster:
+    enabled: true
+    namePrefix: ""     # e.g. '{{ .Values.global.env }}-memgraph-adr'
+    domain: ""         # e.g. '{{ .Values.global.internalDomainSuffix }}'
+    coordinatorCount: 3
+    dataCount: 3
+    startIndex: 11
+    scheme: http       # http | https
+    metricsPort: 9091
+    skipTlsVerify: true
+  # 2) Explicit list (overrides cluster). Fields are tpl-rendered.
+  instances: []
+  # 1) Ready ha_config.yaml from a Secret (overrides both above).
+  existingSecret:
+    name: ""
+    key: ha_config.yaml
+
+# Roll the Deployment on Secret change (needs Stakater Reloader); templated modes roll via a config checksum.
+reloaderEnabled: false
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 10000
+  seccompProfile:
+    type: RuntimeDefault
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: metrics
+readinessProbe:
+  httpGet:
+    path: /
+    port: metrics
+
+extraEnv: []
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    memory: 128Mi
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+service:
+  type: ClusterIP
+  annotations: {}
+  labels: {}
+
+serviceMonitor:
+  # Enable only where the Prometheus Operator CRDs are installed.
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels: {}
+  targetLabels: []
+  honorLabels: false
+  relabelings: []
+  metricRelabelings: []


### PR DESCRIPTION
Add a standalone Helm chart, `memgraph-prometheus-exporter`, for the HA Prometheus exporter ([memgraph/prometheus-exporter](https://github.com/memgraph/prometheus-exporter)).

It deploys the exporter on its own — a `Deployment` + `Service` + optional `ServiceMonitor` — for the case where Memgraph runs **outside** Kubernetes (e.g. on EC2) and only the exporter is needed in-cluster. The existing `memgraph-high-availability` chart already bundles the exporter alongside Memgraph; this chart covers the "exporter-only" deployment.

The exporter needs an explicit per-node list. The chart builds its `ha_config.yaml` three interchangeable ways (precedence `existingSecret` > `instances` > `cluster`):

- **cluster** (default) — derives every node URL from the deterministic naming `‹namePrefix›-{coordinator,data}-‹startIndex+i›.‹domain›`; all string fields are `tpl`-rendered.
- **instances** — an explicit list of `{name, url, port, type}`.
- **existingSecret** — mount a ready `ha_config.yaml` from a Secret (e.g. synced from a secrets manager).

Highlights:
- Hardened Deployment: `runAsNonRoot`, `readOnlyRootFilesystem`, drop `ALL` capabilities, no service-account token.
- `global.imageRegistry` override for private mirrors.
- `checksum/ha-config` annotation rolls the pod when the templated/explicit config changes; optional Stakater Reloader for the `existingSecret` mode.
- `ci/` value files and a `lint-test-prometheus-exporter.yaml` workflow mirroring the other charts.

Note: the exporter requires Memgraph to serve **JSON** on `:9091` (its default) — not OpenMetrics.

